### PR TITLE
fix(sqlite-fts): strip punctuation from query tokens to avoid FTS5 syntax errors

### DIFF
--- a/src/biblicus/retrievers/sqlite_full_text_search.py
+++ b/src/biblicus/retrievers/sqlite_full_text_search.py
@@ -4,6 +4,7 @@ SQLite full-text search version five retriever for Biblicus.
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
@@ -293,7 +294,9 @@ def _tokenize_query(query_text: str) -> List[str]:
     :return: Token list.
     :rtype: list[str]
     """
-    return [token for token in query_text.lower().split() if token]
+    tokens = [token for token in query_text.lower().split() if token]
+    stripped = [re.sub(r"^[\W_]+|[\W_]+$", "", t) for t in tokens]
+    return [t for t in stripped if t]
 
 
 def _resolve_stop_words(value: Optional[Union[str, List[str]]]) -> Set[str]:


### PR DESCRIPTION
When the user query contains punctuation (e.g. "what agreement do we have with Acme?"), tokens like "acme?" were passed unchanged to SQLite FTS5. FTS5 treats "?" as special syntax (prefix/wildcard), which triggers:

  sqlite3.OperationalError: fts5: syntax error near "?"

Fix: in _tokenize_query(), strip leading and trailing non-word characters from each token (using a regex) before building the FTS5 MATCH string. So "acme?" becomes "acme" and the query runs without error. Other punctuation (e.g. "-", "(", ")") that FTS5 treats as special is also removed from token boundaries.

https://gist.github.com/osledybazo/ca871c393e39e6c0865ba98dfe70e38c#file-gistfile2-txt