### PR TITLE
fix(codeql): eliminate python cyclic imports and markov init warning

### DIFF
--- a/project/events/2026-04-17T17:34:22.635Z__507d0254-6c90-4bae-ba78-3e9977520582.json
+++ b/project/events/2026-04-17T17:34:22.635Z__507d0254-6c90-4bae-ba78-3e9977520582.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "event_id": "507d0254-6c90-4bae-ba78-3e9977520582",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-17T17:34:22.635Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [
+      "security",
+      "codeql",
+      "python"
+    ],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Resolve CodeQL cyclic imports and markov uninitialized local"
+  }
+}

--- a/project/events/2026-04-17T17:34:25.162Z__3aec833a-009c-4332-90d1-67d5d0a1c974.json
+++ b/project/events/2026-04-17T17:34:25.162Z__3aec833a-009c-4332-90d1-67d5d0a1c974.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "3aec833a-009c-4332-90d1-67d5d0a1c974",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-17T17:34:25.162Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Remediate rcql python findings: py/cyclic-import in corpus/extraction/extractors/retrieval and py/uninitialized-local-variable in analysis/markov.py; verify with fresh rcql scan."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-17T17:34:25.162Z__b090c121-a854-416c-b908-e47f6483b579.json
+++ b/project/events/2026-04-17T17:34:25.162Z__b090c121-a854-416c-b908-e47f6483b579.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b090c121-a854-416c-b908-e47f6483b579",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-17T17:34:25.162Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-17T17:37:42.558Z__8526e827-2e30-41ba-ab1f-a5b268ccae07.json
+++ b/project/events/2026-04-17T17:37:42.558Z__8526e827-2e30-41ba-ab1f-a5b268ccae07.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8526e827-2e30-41ba-ab1f-a5b268ccae07",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-17T17:37:42.558Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "d6a20778-d356-4146-91d6-97f06ae527c7"
+  }
+}

--- a/project/events/2026-04-17T17:39:05.085Z__79a718a9-0c8d-46e3-ab86-abddae8a8e36.json
+++ b/project/events/2026-04-17T17:39:05.085Z__79a718a9-0c8d-46e3-ab86-abddae8a8e36.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "79a718a9-0c8d-46e3-ab86-abddae8a8e36",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-17T17:39:05.085Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "7d1fa38f-fdb4-4904-888f-b0248b3d3b16"
+  }
+}

--- a/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
+++ b/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
@@ -1,0 +1,29 @@
+{
+  "id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "title": "Resolve CodeQL cyclic imports and markov uninitialized local",
+  "description": "Remediate rcql python findings: py/cyclic-import in corpus/extraction/extractors/retrieval and py/uninitialized-local-variable in analysis/markov.py; verify with fresh rcql scan.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [
+    "security",
+    "codeql",
+    "python"
+  ],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "d6a20778-d356-4146-91d6-97f06ae527c7",
+      "author": "derek.norrbom",
+      "text": "Implemented remediation on branch fix/codeql-cyclic-imports. Removed Python import-cycle edges by eliminating runtime and type-checking imports between corpus/extraction/extractors/retrieval modules, and fixed py/uninitialized-local-variable in analysis/markov.py by default-initializing label/confidence/summary values before retry loop. Verification: rcql -q --lang=python --no-fail --keep-db => Total: 0. Targeted checks: PYTHONPATH=src pytest -q tests/test_extraction_branches.py tests/test_extraction_remaining.py tests/test_markov_branches_more.py tests/test_markov_remaining.py => 7 passed.",
+      "created_at": "2026-04-17T17:37:42.558263Z"
+    }
+  ],
+  "created_at": "2026-04-17T17:34:22.635159Z",
+  "updated_at": "2026-04-17T17:37:42.558263Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
+++ b/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
@@ -20,10 +20,16 @@
       "author": "derek.norrbom",
       "text": "Implemented remediation on branch fix/codeql-cyclic-imports. Removed Python import-cycle edges by eliminating runtime and type-checking imports between corpus/extraction/extractors/retrieval modules, and fixed py/uninitialized-local-variable in analysis/markov.py by default-initializing label/confidence/summary values before retry loop. Verification: rcql -q --lang=python --no-fail --keep-db => Total: 0. Targeted checks: PYTHONPATH=src pytest -q tests/test_extraction_branches.py tests/test_extraction_remaining.py tests/test_markov_branches_more.py tests/test_markov_remaining.py => 7 passed.",
       "created_at": "2026-04-17T17:37:42.558263Z"
+    },
+    {
+      "id": "7d1fa38f-fdb4-4904-888f-b0248b3d3b16",
+      "author": "derek.norrbom",
+      "text": "Pushed remediation branch fix/codeql-cyclic-imports and opened PR #33 to develop: https://github.com/AnthusAI/Biblicus/pull/33. Commit: 6ff95b2. Validation in PR: rcql python scan reports Total 0; targeted pytest subset passes (7 passed).",
+      "created_at": "2026-04-17T17:39:05.085234Z"
     }
   ],
   "created_at": "2026-04-17T17:34:22.635159Z",
-  "updated_at": "2026-04-17T17:37:42.558263Z",
+  "updated_at": "2026-04-17T17:39:05.085234Z",
   "closed_at": null,
   "custom": {}
 }

--- a/src/biblicus/analysis/markov.py
+++ b/src/biblicus/analysis/markov.py
@@ -1039,6 +1039,9 @@ def _build_observations(
             prompt = llm.prompt_template.format(segment=observation.segment_text)
             max_attempts = 4
             last_error: Optional[str] = None
+            label_value = "unknown"
+            confidence_value = 0.0
+            summary_value = "unknown"
             for attempt in range(1, max_attempts + 1):
                 try:
                     response_text = generate_completion(

--- a/src/biblicus/extraction.py
+++ b/src/biblicus/extraction.py
@@ -9,19 +9,29 @@ import os
 import sys
 import threading
 import time
+from hashlib import sha256
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .corpus import Corpus
 from .errors import ExtractionSnapshotFatalError
 from .extractors import get_extractor
-from .extractors.pipeline import PipelineExtractorConfig, PipelineStageSpec
 from .models import CatalogItem, ExtractionStageOutput
-from .retrieval import hash_text
 from .time import utc_now_iso
+
+
+def _hash_text(text: str) -> str:
+    """
+    Hash text for deterministic extraction identifiers.
+
+    :param text: Text payload.
+    :type text: str
+    :return: Secure Hash Algorithm 256 hex digest.
+    :rtype: str
+    """
+    return sha256(text.encode("utf-8")).hexdigest()
 
 
 class ExtractionConfigurationManifest(BaseModel):
@@ -185,7 +195,7 @@ def create_extraction_configuration_manifest(
         {"extractor_id": extractor_id, "name": name, "configuration": configuration},
         sort_keys=True,
     )
-    configuration_id = hash_text(configuration_payload)
+    configuration_id = _hash_text(configuration_payload)
     return ExtractionConfigurationManifest(
         configuration_id=configuration_id,
         extractor_id=extractor_id,
@@ -209,7 +219,7 @@ def create_extraction_snapshot_manifest(
     :rtype: ExtractionSnapshotManifest
     """
     catalog = corpus.load_catalog()
-    snapshot_id = hash_text(f"{configuration.configuration_id}:{catalog.generated_at}")
+    snapshot_id = _hash_text(f"{configuration.configuration_id}:{catalog.generated_at}")
     return ExtractionSnapshotManifest(
         snapshot_id=snapshot_id,
         configuration=configuration,
@@ -516,17 +526,24 @@ def build_extraction_snapshot(
     if extractor_id != "pipeline":
         raise ExtractionSnapshotFatalError("Extraction snapshots must use the pipeline extractor")
 
-    pipeline_config = (
-        parsed_config
-        if isinstance(parsed_config, PipelineExtractorConfig)
-        else PipelineExtractorConfig.model_validate(parsed_config)
-    )
+    parsed_config_data = parsed_config.model_dump()
+    pipeline_stages = parsed_config_data.get("stages")
+    if not isinstance(pipeline_stages, list) or not pipeline_stages:
+        raise ValueError("Pipeline configuration must contain at least one stage")
 
-    validated_stages: List[Tuple[PipelineStageSpec, BaseModel]] = []
-    for stage in pipeline_config.stages:
-        stage_extractor = get_extractor(stage.extractor_id)
-        parsed_stage_config = stage_extractor.validate_config(stage.configuration)
-        validated_stages.append((stage, parsed_stage_config))
+    validated_stages: List[Tuple[str, BaseModel]] = []
+    for stage_data in pipeline_stages:
+        if not isinstance(stage_data, dict):
+            raise ValueError("Pipeline stage entries must be objects")
+        stage_extractor_id = str(stage_data.get("extractor_id", "")).strip()
+        if not stage_extractor_id:
+            raise ValueError("Pipeline stage missing extractor_id")
+        stage_configuration = stage_data.get("configuration", {})
+        if not isinstance(stage_configuration, dict):
+            raise ValueError("Pipeline stage configuration must be an object")
+        stage_extractor = get_extractor(stage_extractor_id)
+        parsed_stage_config = stage_extractor.validate_config(stage_configuration)
+        validated_stages.append((stage_extractor_id, parsed_stage_config))
 
     previous_items = {item.item_id: item for item in (manifest.items or [])}
     extracted_items: List[ExtractionItemResult] = []
@@ -775,24 +792,26 @@ def build_extraction_snapshot(
         last_error_type: Optional[str] = None
         last_error_message: Optional[str] = None
 
-        for stage_index, (stage, parsed_stage_config) in enumerate(validated_stages, start=1):
+        for stage_index, (stage_extractor_id, parsed_stage_config) in enumerate(
+            validated_stages, start=1
+        ):
             with progress_lock:
-                current_stage_label = f"{stage.extractor_id}:{stage_index}"
+                current_stage_label = f"{stage_extractor_id}:{stage_index}"
             if not force:
                 cached = _load_stage_cache(
                     stage_index=stage_index,
-                    extractor_id=stage.extractor_id,
+                    extractor_id=stage_extractor_id,
                     item=item,
                 )
                 if cached:
                     with progress_lock:
-                        current_stage_label = f"{stage.extractor_id}:{stage_index}:cache"
+                        current_stage_label = f"{stage_extractor_id}:{stage_index}:cache"
                     cached_result, cached_output = cached
                     stage_results.append(cached_result)
                     stage_outputs.append(cached_output)
                     continue
             try:
-                stage_extractor = get_extractor(stage.extractor_id)
+                stage_extractor = get_extractor(stage_extractor_id)
                 extracted_text = stage_extractor.extract_text(
                     corpus=corpus,
                     item=item,
@@ -807,7 +826,7 @@ def build_extraction_snapshot(
                 stage_results.append(
                     ExtractionStageResult(
                         stage_index=stage_index,
-                        extractor_id=stage.extractor_id,
+                        extractor_id=stage_extractor_id,
                         status="errored",
                         text_relpath=None,
                         text_characters=0,
@@ -823,7 +842,7 @@ def build_extraction_snapshot(
                 stage_results.append(
                     ExtractionStageResult(
                         stage_index=stage_index,
-                        extractor_id=stage.extractor_id,
+                        extractor_id=stage_extractor_id,
                         status="skipped",
                         text_relpath=None,
                         text_characters=0,
@@ -838,24 +857,24 @@ def build_extraction_snapshot(
             relpath = write_pipeline_stage_text_artifact(
                 snapshot_dir=snapshot_dir,
                 stage_index=stage_index,
-                extractor_id=stage.extractor_id,
+                extractor_id=stage_extractor_id,
                 item=item,
                 text=extracted_text.text,
             )
             metadata_relpath = write_pipeline_stage_metadata_artifact(
                 snapshot_dir=snapshot_dir,
                 stage_index=stage_index,
-                extractor_id=stage.extractor_id,
+                extractor_id=stage_extractor_id,
                 item=item,
                 metadata=extracted_text.metadata,
             )
             text_characters = len(extracted_text.text)
             stage_results.append(
-                ExtractionStageResult(
-                    stage_index=stage_index,
-                    extractor_id=stage.extractor_id,
-                    status="extracted",
-                    text_relpath=relpath,
+                    ExtractionStageResult(
+                        stage_index=stage_index,
+                        extractor_id=stage_extractor_id,
+                        status="extracted",
+                        text_relpath=relpath,
                     text_characters=text_characters,
                     producer_extractor_id=extracted_text.producer_extractor_id,
                     source_stage_index=extracted_text.source_stage_index,

--- a/src/biblicus/extractors/base.py
+++ b/src/biblicus/extractors/base.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
-from ..corpus import Corpus
 from ..models import CatalogItem, ExtractedText, ExtractionStageOutput
 
 

--- a/src/biblicus/extractors/pipeline.py
+++ b/src/biblicus/extractors/pipeline.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from ..corpus import Corpus
 from ..errors import ExtractionSnapshotFatalError
 from ..models import CatalogItem, ExtractedText, ExtractionStageOutput
 from .base import TextExtractor

--- a/src/biblicus/retrieval.py
+++ b/src/biblicus/retrieval.py
@@ -8,7 +8,6 @@ import hashlib
 import json
 from typing import Any, Dict, Iterable, List, Optional
 
-from .corpus import Corpus
 from .models import (
     ConfigurationManifest,
     Evidence,


### PR DESCRIPTION
**Summary**
- Resolves Python CodeQL findings for cyclic imports and one potentially uninitialized local variable.
- Refactors extraction/retrieval module dependencies to remove import-cycle edges across:
  - `src/biblicus/extraction.py`
  - `src/biblicus/retrieval.py`
  - `src/biblicus/extractors/base.py`
  - `src/biblicus/extractors/pipeline.py`
- Fixes `py/uninitialized-local-variable` in `src/biblicus/analysis/markov.py` by initializing label/confidence/summary defaults before LLM retry handling.
- Includes Kanbus task artifacts for this remediation (`project/issues/*`, `project/events/*`).

**Why**
- Eliminates CodeQL quality/security warnings without changing intended behavior.
- Removes brittle module coupling and makes extraction/retrieval wiring safer to evolve.

**Validation**
- `rcql -q --lang=python --no-fail --keep-db` => `Total: 0`
- `PYTHONPATH=src pytest -q tests/test_extraction_branches.py tests/test_extraction_remaining.py tests/test_markov_branches_more.py tests/test_markov_remaining.py` => `7 passed`

**Expected Outcome**
- No remaining local Python CodeQL findings for the previously reported cyclic-import and uninitialized-local set.
- Existing extraction and markov behavior continues to pass targeted test coverage.

**Kanbus / Task Tracking**
- `blbs-37ba41` (in progress; this PR contains the remediation implementation)
