### PR TITLE
fix(tests): align extraction tests with canonical module ownership

### DIFF
--- a/project/events/2026-04-17T17:58:56.885Z__cd480515-5917-4c2c-89b4-7f2381a00004.json
+++ b/project/events/2026-04-17T17:58:56.885Z__cd480515-5917-4c2c-89b4-7f2381a00004.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cd480515-5917-4c2c-89b4-7f2381a00004",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-17T17:58:56.885Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "3dcd5d95-2dcd-458c-9436-ef0c60db635c"
+  }
+}

--- a/project/events/2026-04-17T18:00:27.461Z__2b41119e-db30-4933-a03d-9c91474a93cc.json
+++ b/project/events/2026-04-17T18:00:27.461Z__2b41119e-db30-4933-a03d-9c91474a93cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2b41119e-db30-4933-a03d-9c91474a93cc",
+  "issue_id": "blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-17T18:00:27.461Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "eb44accf-e4d2-4770-b099-853529e7c109"
+  }
+}

--- a/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
+++ b/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
@@ -32,10 +32,16 @@
       "author": "derek.norrbom",
       "text": "Follow-up lint fix pushed in commit 2fec4f2 and PR #34 opened to develop: https://github.com/AnthusAI/Biblicus/pull/34. Addresses CI Ruff failures (F821/I001) in extraction modules. Validation: poetry run ruff check src/biblicus/ => All checks passed.",
       "created_at": "2026-04-17T17:43:47.776418Z"
+    },
+    {
+      "id": "3dcd5d95-2dcd-458c-9436-ef0c60db635c",
+      "author": "derek.norrbom",
+      "text": "Applied senior-level fix for CI extraction regressions without compatibility shims: updated extraction tests to use canonical APIs/module ownership (create_extraction_snapshot_manifest for snapshot IDs, PipelineExtractorConfig from biblicus.extractors.pipeline). Validation: poetry run ruff check src/biblicus/ and poetry run python scripts/test.py both pass locally.",
+      "created_at": "2026-04-17T17:58:56.884973Z"
     }
   ],
   "created_at": "2026-04-17T17:34:22.635159Z",
-  "updated_at": "2026-04-17T17:43:47.776418Z",
+  "updated_at": "2026-04-17T17:58:56.884973Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
+++ b/project/issues/blbs-37ba4176-a7b8-40a9-a919-6c81af72cad5.json
@@ -38,10 +38,16 @@
       "author": "derek.norrbom",
       "text": "Applied senior-level fix for CI extraction regressions without compatibility shims: updated extraction tests to use canonical APIs/module ownership (create_extraction_snapshot_manifest for snapshot IDs, PipelineExtractorConfig from biblicus.extractors.pipeline). Validation: poetry run ruff check src/biblicus/ and poetry run python scripts/test.py both pass locally.",
       "created_at": "2026-04-17T17:58:56.884973Z"
+    },
+    {
+      "id": "eb44accf-e4d2-4770-b099-853529e7c109",
+      "author": "derek.norrbom",
+      "text": "Opened follow-up PR #35 to develop for extraction test boundary fixes: https://github.com/AnthusAI/Biblicus/pull/35. Commit: 9461402. Validation included in PR body: ruff src/biblicus pass; scripts/test.py pass (146 features, 287 pytest tests).",
+      "created_at": "2026-04-17T18:00:27.461524Z"
     }
   ],
   "created_at": "2026-04-17T17:34:22.635159Z",
-  "updated_at": "2026-04-17T17:58:56.884973Z",
+  "updated_at": "2026-04-17T18:00:27.461524Z",
   "closed_at": null,
   "custom": {}
 }

--- a/tests/test_extraction_branches_extra.py
+++ b/tests/test_extraction_branches_extra.py
@@ -3,9 +3,10 @@ from types import SimpleNamespace
 from pathlib import Path
 
 from biblicus.extraction import (
-    load_or_build_extraction_snapshot,
     create_extraction_configuration_manifest,
+    create_extraction_snapshot_manifest,
     ExtractionSnapshotManifest,
+    load_or_build_extraction_snapshot,
 )
 
 
@@ -52,7 +53,7 @@ def test_load_or_build_uses_existing_manifest(tmp_path: Path):
 
 
 def test_extraction_uses_cached_final_text(tmp_path: Path):
-    from biblicus.extraction import build_extraction_snapshot, hash_text
+    from biblicus.extraction import build_extraction_snapshot
     from biblicus.models import CatalogItem, CorpusCatalog
     from biblicus.corpus import Corpus
 
@@ -83,7 +84,8 @@ def test_extraction_uses_cached_final_text(tmp_path: Path):
     config_manifest = create_extraction_configuration_manifest(
         extractor_id="pipeline", name="cfg", configuration={"stages": []}
     )
-    snapshot_id = hash_text(f"{config_manifest.configuration_id}:{catalog.generated_at}")
+    snapshot_manifest = create_extraction_snapshot_manifest(corpus, configuration=config_manifest)
+    snapshot_id = snapshot_manifest.snapshot_id
     snapshot_dir = corpus.extraction_snapshot_dir(extractor_id="pipeline", snapshot_id=snapshot_id)
     snapshot_dir.mkdir(parents=True, exist_ok=True)
     text_dir = snapshot_dir / "text"
@@ -103,7 +105,7 @@ def test_extraction_uses_cached_final_text(tmp_path: Path):
 
 
 def test_extraction_reuses_stage_cache(tmp_path: Path):
-    from biblicus.extraction import build_extraction_snapshot, hash_text, _pipeline_stage_dir_name
+    from biblicus.extraction import build_extraction_snapshot, _pipeline_stage_dir_name
     from biblicus.models import CatalogItem, CorpusCatalog
     from biblicus.corpus import Corpus
 
@@ -134,7 +136,8 @@ def test_extraction_reuses_stage_cache(tmp_path: Path):
     config_manifest = create_extraction_configuration_manifest(
         extractor_id="pipeline", name="cfg2", configuration={"stages": [{"extractor_id": "pass-through-text"}]}
     )
-    snapshot_id = hash_text(f"{config_manifest.configuration_id}:{catalog.generated_at}")
+    snapshot_manifest = create_extraction_snapshot_manifest(corpus, configuration=config_manifest)
+    snapshot_id = snapshot_manifest.snapshot_id
     snapshot_dir = corpus.extraction_snapshot_dir(extractor_id="pipeline", snapshot_id=snapshot_id)
     stage_dir_name = _pipeline_stage_dir_name(stage_index=1, extractor_id="pass-through-text")
     stage_dir = snapshot_dir / "stages" / stage_dir_name
@@ -155,7 +158,7 @@ def test_extraction_reuses_stage_cache(tmp_path: Path):
 
 
 def test_extraction_stage_cache_loads_metadata(tmp_path: Path):
-    from biblicus.extraction import build_extraction_snapshot, hash_text, _pipeline_stage_dir_name
+    from biblicus.extraction import build_extraction_snapshot, _pipeline_stage_dir_name
     from biblicus.models import CatalogItem, CorpusCatalog
     from biblicus.corpus import Corpus
 
@@ -186,7 +189,8 @@ def test_extraction_stage_cache_loads_metadata(tmp_path: Path):
     config_manifest = create_extraction_configuration_manifest(
         extractor_id="pipeline", name="cfg3", configuration={"stages": [{"extractor_id": "pass-through-text"}]}
     )
-    snapshot_id = hash_text(f"{config_manifest.configuration_id}:{catalog.generated_at}")
+    snapshot_manifest = create_extraction_snapshot_manifest(corpus, configuration=config_manifest)
+    snapshot_id = snapshot_manifest.snapshot_id
     snapshot_dir = corpus.extraction_snapshot_dir(extractor_id="pipeline", snapshot_id=snapshot_id)
     stage_dir_name = _pipeline_stage_dir_name(stage_index=1, extractor_id="pass-through-text")
     stage_dir = snapshot_dir / "stages" / stage_dir_name

--- a/tests/test_extraction_remaining_precision.py
+++ b/tests/test_extraction_remaining_precision.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 from biblicus import extraction
 from biblicus.corpus import Corpus
+from biblicus.extractors.pipeline import PipelineExtractorConfig
 
 
 def test_extraction_log_interval_and_heartbeat(monkeypatch, tmp_path, capsys):
@@ -18,7 +19,7 @@ def test_extraction_log_interval_and_heartbeat(monkeypatch, tmp_path, capsys):
                 extractor_id = "pipeline"
 
                 def validate_config(self, config):  # noqa: D401
-                    return extraction.PipelineExtractorConfig.model_validate(config)
+                    return PipelineExtractorConfig.model_validate(config)
 
             return DummyPipelineExtractor()
 


### PR DESCRIPTION
**Summary**
- Update extraction regression tests to use canonical module ownership instead of cross-module internals.
- Replace direct hash_text usage in extraction snapshot tests with create_extraction_snapshot_manifest-derived snapshot IDs.
- Import PipelineExtractorConfig from biblicus.extractors.pipeline in precision tests instead of accessing it via biblicus.extraction.
- Include Kanbus artifact updates for task traceability.

**Why**
- Recent CodeQL/cycle-breaking refactors removed non-canonical symbols from biblicus.extraction, which caused CI test failures.
- This keeps boundaries explicit and avoids compatibility shims or fallback-style API aliases.

**Validation**
- poetry run ruff check src/biblicus/ (pass)
- poetry run python scripts/test.py (pass; 146 features, 287 pytest tests)

**Expected Outcome**
- CI no longer fails on extraction test imports after the module-boundary refactor.
- Tests now depend on stable owning modules and canonical snapshot-manifest APIs.

**Kanbus / Task Tracking**
- blbs-37ba41 (in progress; updated with this fix and validation)
