### PR TITLE
chore: commit kanbus artifacts for blbs-7e43f4

### DIFF
--- a/project/events/2026-05-05T19:20:11.977Z__e17cd1b7-4ec9-46bb-b0c9-d5bc8bda489f.json
+++ b/project/events/2026-05-05T19:20:11.977Z__e17cd1b7-4ec9-46bb-b0c9-d5bc8bda489f.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "e17cd1b7-4ec9-46bb-b0c9-d5bc8bda489f",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T19:20:11.977Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "blbs-ded60666-6844-4c08-a569-07ded185096c",
+    "priority": 0,
+    "status": "open",
+    "title": "Remediate Snyk gitpython transitive vulnerability from python-semantic-release"
+  }
+}

--- a/project/events/2026-05-05T19:20:14.490Z__b51f9eb9-041f-4983-b35a-7037dd668009.json
+++ b/project/events/2026-05-05T19:20:14.490Z__b51f9eb9-041f-4983-b35a-7037dd668009.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b51f9eb9-041f-4983-b35a-7037dd668009",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T19:20:14.490Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T19:20:14.491Z__67a58e04-e929-425c-866c-fe79af641163.json
+++ b/project/events/2026-05-05T19:20:14.491Z__67a58e04-e929-425c-866c-fe79af641163.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67a58e04-e929-425c-866c-fe79af641163",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:20:14.491Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "1a939a09-c771-4269-b62f-45905b256a21"
+  }
+}

--- a/project/events/2026-05-05T19:25:19.929Z__58eb1d17-bbe0-407e-8688-5445473b1ede.json
+++ b/project/events/2026-05-05T19:25:19.929Z__58eb1d17-bbe0-407e-8688-5445473b1ede.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "58eb1d17-bbe0-407e-8688-5445473b1ede",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:25:19.929Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "f42d0756-9fca-4a1c-bba8-d638d5d1ae30"
+  }
+}

--- a/project/events/2026-05-05T19:27:17.252Z__ba135e8e-5034-4dfb-a7b3-885f132424b8.json
+++ b/project/events/2026-05-05T19:27:17.252Z__ba135e8e-5034-4dfb-a7b3-885f132424b8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ba135e8e-5034-4dfb-a7b3-885f132424b8",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:27:17.252Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "0533a757-f645-4412-afaa-82ea8ac246c0"
+  }
+}

--- a/project/events/2026-05-05T19:36:48.788Z__a87bb148-4a8a-42bd-b1ca-6d92029b8342.json
+++ b/project/events/2026-05-05T19:36:48.788Z__a87bb148-4a8a-42bd-b1ca-6d92029b8342.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a87bb148-4a8a-42bd-b1ca-6d92029b8342",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:36:48.788Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "26e72735-0571-4147-9211-c06838f92504"
+  }
+}

--- a/project/events/2026-05-05T19:44:33.012Z__9d0c35fd-d420-4ef4-abfd-154ca72997e0.json
+++ b/project/events/2026-05-05T19:44:33.012Z__9d0c35fd-d420-4ef4-abfd-154ca72997e0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9d0c35fd-d420-4ef4-abfd-154ca72997e0",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:44:33.012Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "451262b0-bad2-4265-850e-b9d0cb7d5d6f"
+  }
+}

--- a/project/events/2026-05-05T19:44:49.913Z__67d1bc4b-56b8-4c69-8128-00b4abdd9b43.json
+++ b/project/events/2026-05-05T19:44:49.913Z__67d1bc4b-56b8-4c69-8128-00b4abdd9b43.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67d1bc4b-56b8-4c69-8128-00b4abdd9b43",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T19:44:49.913Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "e8283e8d-e600-4233-8d00-298aa6e2010c"
+  }
+}

--- a/project/events/2026-05-05T19:44:49.918Z__ed3796db-fa65-44f6-b664-0ea9385f61a7.json
+++ b/project/events/2026-05-05T19:44:49.918Z__ed3796db-fa65-44f6-b664-0ea9385f61a7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ed3796db-fa65-44f6-b664-0ea9385f61a7",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T19:44:49.918Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T20:27:44.579Z__57ae81df-1257-4d92-8184-503392ad88a7.json
+++ b/project/events/2026-05-05T20:27:44.579Z__57ae81df-1257-4d92-8184-503392ad88a7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "57ae81df-1257-4d92-8184-503392ad88a7",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T20:27:44.579Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "078f89df-eab0-4d13-b096-af1cacb2ab57"
+  }
+}

--- a/project/events/2026-05-05T20:28:06.799Z__d372a23a-5948-4ba9-8471-8b50da1807b3.json
+++ b/project/events/2026-05-05T20:28:06.799Z__d372a23a-5948-4ba9-8471-8b50da1807b3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d372a23a-5948-4ba9-8471-8b50da1807b3",
+  "issue_id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T20:28:06.799Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "e55bb4d4-58fc-44df-a888-9e9455de9ef3"
+  }
+}

--- a/project/issues/blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965.json
+++ b/project/issues/blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965.json
@@ -52,10 +52,16 @@
       "author": "derek.norrbom",
       "text": "Follow-up housekeeping: committing Kanbus-generated project/events and project/issues artifacts that were produced during task execution and were unintentionally left uncommitted in the prior PR.",
       "created_at": "2026-05-05T20:27:44.579219Z"
+    },
+    {
+      "id": "e55bb4d4-58fc-44df-a888-9e9455de9ef3",
+      "author": "derek.norrbom",
+      "text": "Committed and pushed Kanbus artifact follow-up.\nBranch: feature/blbs-7e43f4-kanbus-artifacts\nCommit: effdba1\nPR: https://github.com/AnthusAI/Biblicus/pull/40",
+      "created_at": "2026-05-05T20:28:06.799042Z"
     }
   ],
   "created_at": "2026-05-05T19:20:11.977089Z",
-  "updated_at": "2026-05-05T20:27:44.579219Z",
+  "updated_at": "2026-05-05T20:28:06.799042Z",
   "closed_at": "2026-05-05T19:44:49.918046Z",
   "custom": {}
 }

--- a/project/issues/blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965.json
+++ b/project/issues/blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965.json
@@ -1,0 +1,61 @@
+{
+  "id": "blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965",
+  "title": "Remediate Snyk gitpython transitive vulnerability from python-semantic-release",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": "blbs-ded60666-6844-4c08-a569-07ded185096c",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "1a939a09-c771-4269-b62f-45905b256a21",
+      "author": "derek.norrbom",
+      "text": "Started triage for Snyk report: python-semantic-release transitive GitPython vulnerability (argument/command injection). Investigating pyproject constraints vs lockfile resolution and applying minimal dependency fix.",
+      "created_at": "2026-05-05T19:20:14.491784Z"
+    },
+    {
+      "id": "f42d0756-9fca-4a1c-bba8-d638d5d1ae30",
+      "author": "derek.norrbom",
+      "text": "Applied fix path preferred by user: tightened dev dependency to python-semantic-release>=10.5.3 and regenerated lockfile. Resulting resolution now pins gitpython to 3.1.49. Verified with snyk test --all-projects --dev --severity-threshold=high: GitPython critical/high findings are gone; remaining findings are unrelated no-fix torch/transformers advisories.",
+      "created_at": "2026-05-05T19:25:19.929180Z"
+    },
+    {
+      "id": "0533a757-f645-4412-afaa-82ea8ac246c0",
+      "author": "derek.norrbom",
+      "text": "Follow-up triage: pyproject already resolves dotyaml==1.1.1. Current Snyk finding is transitive python-dotenv@1.0.1 introduced by dotyaml. Implementing minimal fix by constraining python-dotenv>=1.2.2 and re-locking, then validating with Snyk and smoke tests.",
+      "created_at": "2026-05-05T19:27:17.252180Z"
+    },
+    {
+      "id": "26e72735-0571-4147-9211-c06838f92504",
+      "author": "derek.norrbom",
+      "text": "Investigated litellm concern. Current Poetry index reports litellm 1.83.3 as latest and lockfile has litellm 1.83.3 (optional dspy extra). Current Snyk CLI output does not report litellm-specific vulnerabilities; active fixable findings remain gitpython and python-dotenv. python-dotenv is also pinned by litellm 1.83.3.",
+      "created_at": "2026-05-05T19:36:48.788397Z"
+    },
+    {
+      "id": "451262b0-bad2-4265-850e-b9d0cb7d5d6f",
+      "author": "derek.norrbom",
+      "text": "Implemented dependency hardening in pyproject + lockfile:\n- pyproject: dotyaml>=1.1.1 (was >=0.1.3), python-dotenv>=1.2.2, python-semantic-release>=10.5.3.\n- lockfile: gitpython 3.1.46 -> 3.1.49, python-dotenv 1.0.1 -> 1.2.2.\n- lockfile also resolved optional dspy dependency litellm 1.83.3 -> 1.83.0 to satisfy python-dotenv constraint.\nValidation:\n- snyk test --all-projects --severity-threshold=low => 0 vulnerable paths in default dependency set.\n- snyk test --all-projects --dev --severity-threshold=high => remaining no-fix torch/transformers findings only; gitpython/python-dotenv findings removed.\n- pytest -q => 442 passed.",
+      "created_at": "2026-05-05T19:44:33.012280Z"
+    },
+    {
+      "id": "e8283e8d-e600-4233-8d00-298aa6e2010c",
+      "author": "derek.norrbom",
+      "text": "Completed and pushed to feature branch feature/blbs-7e43f4-snyk-deps.\nCommit: 6743eba\nPR URL seed: https://github.com/AnthusAI/Biblicus/pull/new/feature/blbs-7e43f4-snyk-deps\nTask outcome: resolved fixable Snyk findings for gitpython/python-dotenv while preserving test pass status.",
+      "created_at": "2026-05-05T19:44:49.913003Z"
+    },
+    {
+      "id": "078f89df-eab0-4d13-b096-af1cacb2ab57",
+      "author": "derek.norrbom",
+      "text": "Follow-up housekeeping: committing Kanbus-generated project/events and project/issues artifacts that were produced during task execution and were unintentionally left uncommitted in the prior PR.",
+      "created_at": "2026-05-05T20:27:44.579219Z"
+    }
+  ],
+  "created_at": "2026-05-05T19:20:11.977089Z",
+  "updated_at": "2026-05-05T20:27:44.579219Z",
+  "closed_at": "2026-05-05T19:44:49.918046Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Commit Kanbus task artifacts generated while executing blbs-7e43f4
- Include project event records and the issue record file

## Why
These files were unintentionally left uncommitted in the previous dependency remediation pull request.

## Scope
- project/events/*.json created during task execution
- project/issues/blbs-7e43f40a-9f6c-4dc4-a976-b89c4fc03965.json

## Kanbus
- blbs-7e43f4
