### PR TITLE
fix: prevent zip slip in FUNSD archive extraction

### DIFF
--- a/project/events/2026-05-05T22:15:25.767Z__619eb725-f48b-4499-a1b7-ed546da847fd.json
+++ b/project/events/2026-05-05T22:15:25.767Z__619eb725-f48b-4499-a1b7-ed546da847fd.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "619eb725-f48b-4499-a1b7-ed546da847fd",
+  "issue_id": "blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T22:15:25.767Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "blbs-ded60666-6844-4c08-a569-07ded185096c",
+    "priority": 1,
+    "status": "open",
+    "title": "Remediate archive extraction path traversal in FUNSD sample downloader"
+  }
+}

--- a/project/events/2026-05-05T22:15:30.230Z__8db9ad76-0bb2-47b3-955c-e1cb8fde29ea.json
+++ b/project/events/2026-05-05T22:15:30.230Z__8db9ad76-0bb2-47b3-955c-e1cb8fde29ea.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8db9ad76-0bb2-47b3-955c-e1cb8fde29ea",
+  "issue_id": "blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T22:15:30.230Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T22:15:45.240Z__992f0c0e-0958-49f4-ad99-59212a6d34ac.json
+++ b/project/events/2026-05-05T22:15:45.240Z__992f0c0e-0958-49f4-ad99-59212a6d34ac.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "992f0c0e-0958-49f4-ad99-59212a6d34ac",
+  "issue_id": "blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T22:15:45.240Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "58830f62-f87b-4f32-be2d-b90d67daf7b0"
+  }
+}

--- a/project/issues/blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16.json
+++ b/project/issues/blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16.json
@@ -1,0 +1,25 @@
+{
+  "id": "blbs-6415bada-f01b-4d20-8cf4-be54c3cf8f16",
+  "title": "Remediate archive extraction path traversal in FUNSD sample downloader",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "blbs-ded60666-6844-4c08-a569-07ded185096c",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "58830f62-f87b-4f32-be2d-b90d67daf7b0",
+      "author": "derek.norrbom",
+      "text": "Replaced direct ZipFile.extractall usage with guarded extraction that validates every zip member resolves under destination before extraction; this blocks path traversal (zip slip) writes outside temp_dir.",
+      "created_at": "2026-05-05T22:15:45.240706Z"
+    }
+  ],
+  "created_at": "2026-05-05T22:15:25.767764Z",
+  "updated_at": "2026-05-05T22:15:45.240706Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/scripts/download_funsd_samples.py
+++ b/scripts/download_funsd_samples.py
@@ -26,6 +26,27 @@ FUNSD_DATASET_URL = "https://guillaumejaume.github.io/FUNSD/dataset.zip"
 FUNSD_SAMPLE_COUNT = 5  # Number of samples to ingest for testing
 
 
+def _extract_zip_safely(zip_path: Path, destination: Path) -> None:
+    """
+    Extract a zip archive only when all members resolve within destination.
+
+    :param zip_path: Path to the zip archive.
+    :type zip_path: Path
+    :param destination: Extraction destination directory.
+    :type destination: Path
+    :return: None.
+    :rtype: None
+    :raises ValueError: If any archive member escapes the destination directory.
+    """
+    destination_root = destination.resolve()
+    with zipfile.ZipFile(zip_path, "r") as archive:
+        for member in archive.infolist():
+            member_target = (destination / member.filename).resolve()
+            if destination_root not in member_target.parents and member_target != destination_root:
+                raise ValueError(f"Unsafe archive member path: {member.filename}")
+        archive.extractall(destination)
+
+
 def _prepare_corpus(path: Path, *, force: bool) -> Corpus:
     """
     Initialize or open a corpus for FUNSD sample downloads.
@@ -64,8 +85,7 @@ def download_funsd_dataset(temp_dir: Path) -> Path:
     print(f"✓ Downloaded {zip_path.stat().st_size:,} bytes")
 
     print("Extracting dataset...")
-    with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        zip_ref.extractall(temp_dir)
+    _extract_zip_safely(zip_path, temp_dir)
 
     # Find the extracted dataset directory
     extracted_dir = temp_dir / "dataset"


### PR DESCRIPTION
## Summary
- Replace direct zip extractall call in FUNSD downloader with safe extraction guard.
- Validate every archive member resolves under destination before extraction.
- Raise a clear error on unsafe member path.

## Why
Snyk Code flagged an arbitrary file write risk (zip slip / path traversal) at archive extraction.

## Validation
- python -m py_compile scripts/download_funsd_samples.py

## Kanbus
- blbs-6415ba
