### PR TITLE
Fold foreign catalog item fields into metadata on load

### DIFF
--- a/src/biblicus/catalog_compat.py
+++ b/src/biblicus/catalog_compat.py
@@ -1,0 +1,65 @@
+"""
+Helpers for loading corpus catalogs that carry foreign top-level item fields.
+
+Downstream tools may attach editorial extensions beside the canonical Biblicus
+catalog item shape. Those keys are folded into ``metadata`` on read so strict
+``CatalogItem`` validation succeeds without product-specific schema branches.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .models import CatalogItem, CorpusCatalog
+
+CATALOG_ITEM_ROOT_FIELDS = frozenset(CatalogItem.model_fields.keys())
+
+
+def sanitize_catalog_item_payload(item: Mapping[str, Any]) -> dict[str, Any]:
+    """
+    Normalize one catalog item mapping to the canonical root field set.
+
+    Unknown top-level keys are merged into ``metadata`` so callers can keep
+    strict ``CatalogItem`` validation while preserving extension data.
+    """
+    if not isinstance(item, Mapping):
+        raise TypeError("Catalog item payload must be a mapping.")
+    sanitized: dict[str, Any] = {}
+    metadata = dict(item.get("metadata") or {}) if isinstance(item.get("metadata"), dict) else {}
+    for key, value in item.items():
+        if key == "metadata":
+            continue
+        if key in CATALOG_ITEM_ROOT_FIELDS:
+            sanitized[key] = value
+            continue
+        if key in metadata and isinstance(metadata[key], dict) and isinstance(value, dict):
+            metadata[key] = {**metadata[key], **value}
+        else:
+            metadata[key] = value
+    sanitized["metadata"] = metadata
+    return sanitized
+
+
+def sanitize_catalog_payload(catalog_data: Mapping[str, Any]) -> dict[str, Any]:
+    """
+    Normalize a full catalog document before ``CorpusCatalog`` validation.
+    """
+    if not isinstance(catalog_data, Mapping):
+        raise TypeError("Catalog payload must be a mapping.")
+    sanitized = dict(catalog_data)
+    raw_items = catalog_data.get("items")
+    if not isinstance(raw_items, Mapping):
+        return sanitized
+    sanitized["items"] = {
+        item_id: sanitize_catalog_item_payload(item)
+        for item_id, item in raw_items.items()
+        if isinstance(item, Mapping)
+    }
+    return sanitized
+
+
+def load_corpus_catalog(catalog_data: Mapping[str, Any]) -> CorpusCatalog:
+    """
+    Parse catalog JSON after folding foreign item extensions into metadata.
+    """
+    return CorpusCatalog.model_validate(sanitize_catalog_payload(catalog_data))

--- a/src/biblicus/corpus.py
+++ b/src/biblicus/corpus.py
@@ -16,6 +16,7 @@ from urllib.parse import quote, unquote, urlparse
 import yaml
 from pydantic import ValidationError
 
+from .catalog_compat import load_corpus_catalog
 from .constants import (
     ANALYSIS_DIR_NAME,
     CORPUS_DIR_NAME,
@@ -689,7 +690,7 @@ class Corpus:
         if not self.catalog_path.is_file():
             raise FileNotFoundError(f"Missing corpus catalog: {self.catalog_path}")
         catalog_data = json.loads(self.catalog_path.read_text(encoding="utf-8"))
-        return CorpusCatalog.model_validate(catalog_data)
+        return load_corpus_catalog(catalog_data)
 
     def load_catalog(self) -> CorpusCatalog:
         """

--- a/tests/test_catalog_compat.py
+++ b/tests/test_catalog_compat.py
@@ -1,0 +1,52 @@
+from biblicus.catalog_compat import load_corpus_catalog, sanitize_catalog_item_payload
+
+
+def test_sanitize_catalog_item_payload_folds_foreign_root_fields() -> None:
+    sanitized = sanitize_catalog_item_payload(
+        {
+            "id": "item-1",
+            "relpath": "raw/paper.pdf",
+            "sha256": "abc",
+            "bytes": 10,
+            "media_type": "application/pdf",
+            "created_at": "2026-05-01T00:00:00Z",
+            "title": "Paper title",
+            "identifiers": {"doi": "10.1234/example"},
+            "papyrus": {"quality_rating": {"rating": 4}},
+            "summary": "Short summary",
+            "metadata": {"authors": ["Ada Lovelace"]},
+        }
+    )
+    assert sanitized["title"] == "Paper title"
+    assert "identifiers" not in sanitized
+    assert "papyrus" not in sanitized
+    assert "summary" not in sanitized
+    assert sanitized["metadata"]["authors"] == ["Ada Lovelace"]
+    assert sanitized["metadata"]["identifiers"] == {"doi": "10.1234/example"}
+    assert sanitized["metadata"]["papyrus"] == {"quality_rating": {"rating": 4}}
+    assert sanitized["metadata"]["summary"] == "Short summary"
+
+
+def test_load_corpus_catalog_accepts_extension_polluted_items() -> None:
+    catalog = load_corpus_catalog(
+        {
+            "schema_version": 2,
+            "generated_at": "2026-05-01T00:00:00Z",
+            "corpus_uri": "file:///tmp/demo",
+            "raw_dir": "raw",
+            "items": {
+                "item-1": {
+                    "id": "item-1",
+                    "relpath": "raw/paper.pdf",
+                    "sha256": "abc",
+                    "bytes": 10,
+                    "media_type": "application/pdf",
+                    "created_at": "2026-05-01T00:00:00Z",
+                    "papyrus": {"title_subtitle": {"summary": "Editorial summary"}},
+                }
+            },
+            "order": ["item-1"],
+        }
+    )
+    item = catalog.items["item-1"]
+    assert item.metadata["papyrus"]["title_subtitle"]["summary"] == "Editorial summary"


### PR DESCRIPTION
Cherry-pick of develop commit c97126c.

Corpus catalogs may carry editorial extensions at the item root from downstream tools. Sanitize those keys into \`metadata\` before \`CatalogItem\` validation so steering export and other corpus reads stay strict without product-specific schema branches.

## Testing

\`\`\`bash
uv run pytest tests/test_catalog_compat.py -q
\`\`\`