### PR TITLE
chore(pm): add remaining kanbus artifacts after PR #48 merge

### DIFF
--- a/project/events/2026-05-29T21:34:47.626Z__1f20bb0d-c44b-4f71-bfa2-d26ed9a88b15.json
+++ b/project/events/2026-05-29T21:34:47.626Z__1f20bb0d-c44b-4f71-bfa2-d26ed9a88b15.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "1f20bb0d-c44b-4f71-bfa2-d26ed9a88b15",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-29T21:34:47.626Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "blbs-4130e46d-d9f3-4b30-834e-ba0ab3b13a03",
+    "priority": 1,
+    "status": "open",
+    "title": "Create merge PR from develop to main after green CI"
+  }
+}

--- a/project/events/2026-05-29T21:34:49.733Z__ea2f1752-d8d7-4581-8195-84a1df5df53b.json
+++ b/project/events/2026-05-29T21:34:49.733Z__ea2f1752-d8d7-4581-8195-84a1df5df53b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ea2f1752-d8d7-4581-8195-84a1df5df53b",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-29T21:34:49.733Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "7119f42b-c190-4b0d-89f0-9e5e4a93af03"
+  }
+}

--- a/project/events/2026-05-29T21:34:49.736Z__2a49c500-6c16-4846-b7dd-d322f63ee86a.json
+++ b/project/events/2026-05-29T21:34:49.736Z__2a49c500-6c16-4846-b7dd-d322f63ee86a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2a49c500-6c16-4846-b7dd-d322f63ee86a",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-29T21:34:49.736Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-29T21:35:04.713Z__7a47bf58-ebe9-4930-beeb-992702f5941f.json
+++ b/project/events/2026-05-29T21:35:04.713Z__7a47bf58-ebe9-4930-beeb-992702f5941f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7a47bf58-ebe9-4930-beeb-992702f5941f",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-29T21:35:04.713Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-29T21:35:04.715Z__e4c41f32-888a-4403-8d28-046726970ef9.json
+++ b/project/events/2026-05-29T21:35:04.715Z__e4c41f32-888a-4403-8d28-046726970ef9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e4c41f32-888a-4403-8d28-046726970ef9",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-29T21:35:04.715Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "02cc4977-c850-4aec-95a6-310a382ce918"
+  }
+}

--- a/project/events/2026-05-29T21:36:10.536Z__27431857-83b6-491c-83a4-65af21d5f3ff.json
+++ b/project/events/2026-05-29T21:36:10.536Z__27431857-83b6-491c-83a4-65af21d5f3ff.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "27431857-83b6-491c-83a4-65af21d5f3ff",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-29T21:36:10.536Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "closed",
+    "to_status": "open"
+  }
+}

--- a/project/events/2026-05-29T21:36:10.536Z__8570a658-8f5b-4c35-ba7f-8336fc42023a.json
+++ b/project/events/2026-05-29T21:36:10.536Z__8570a658-8f5b-4c35-ba7f-8336fc42023a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8570a658-8f5b-4c35-ba7f-8336fc42023a",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-29T21:36:10.536Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "e7cb8835-70e7-451e-87e7-2bdc976228e6"
+  }
+}

--- a/project/events/2026-05-29T21:36:13.608Z__cb48ef89-200b-41df-976a-4ea04884025e.json
+++ b/project/events/2026-05-29T21:36:13.608Z__cb48ef89-200b-41df-976a-4ea04884025e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cb48ef89-200b-41df-976a-4ea04884025e",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-29T21:36:13.608Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-29T21:36:21.051Z__67a67d76-dddf-4e6d-9a4c-e26884907d9f.json
+++ b/project/events/2026-05-29T21:36:21.051Z__67a67d76-dddf-4e6d-9a4c-e26884907d9f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67a67d76-dddf-4e6d-9a4c-e26884907d9f",
+  "issue_id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-29T21:36:21.051Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/blbs-120918ce-7620-4212-b7b5-d0bd84df691e.json
+++ b/project/issues/blbs-120918ce-7620-4212-b7b5-d0bd84df691e.json
@@ -1,0 +1,31 @@
+{
+  "id": "blbs-120918ce-7620-4212-b7b5-d0bd84df691e",
+  "title": "Create merge PR from develop to main after green CI",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "blbs-4130e46d-d9f3-4b30-834e-ba0ab3b13a03",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "7119f42b-c190-4b0d-89f0-9e5e4a93af03",
+      "author": "derek.norrbom",
+      "text": "Starting release merge PR flow: creating PR from develop to main after confirming no existing open PR for that head/base pair.",
+      "created_at": "2026-05-29T21:34:49.733203Z"
+    },
+    {
+      "id": "02cc4977-c850-4aec-95a6-310a382ce918",
+      "author": "derek.norrbom",
+      "text": "Opened merge PR from develop to main: https://github.com/AnthusAI/Biblicus/pull/49",
+      "created_at": "2026-05-29T21:35:04.714874Z"
+    }
+  ],
+  "created_at": "2026-05-29T21:34:47.626320Z",
+  "updated_at": "2026-05-29T21:36:13.608341Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/blbs-120918ce-7620-4212-b7b5-d0bd84df691e.json
+++ b/project/issues/blbs-120918ce-7620-4212-b7b5-d0bd84df691e.json
@@ -3,7 +3,7 @@
   "title": "Create merge PR from develop to main after green CI",
   "description": "",
   "type": "task",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -25,7 +25,7 @@
     }
   ],
   "created_at": "2026-05-29T21:34:47.626320Z",
-  "updated_at": "2026-05-29T21:36:13.608341Z",
-  "closed_at": null,
+  "updated_at": "2026-05-29T21:36:21.051089Z",
+  "closed_at": "2026-05-29T21:36:21.051089Z",
   "custom": {}
 }


### PR DESCRIPTION
**Summary**
- Adds follow-up Kanbus artifact commits that were created after PR #48 merged.
- Includes only `project/events/*` and `project/issues/blbs-120918...` updates.

**Why**
- Keeps repository state consistent by landing the remaining tracked Kanbus artifacts on `develop`.

**Validation**
- Compared `origin/develop..feature/snyk-parent-remediation-gitpython-urllib3-idna` and confirmed exactly 2 pending commits.
- `git status -sb` is clean on the branch.

**Expected Outcome**
- After merge, `develop` contains all generated Kanbus artifacts from this workflow.

