### PR TITLE
fix(security): remediate archive extraction tar-slip finding in FUNSD downloader

### DIFF
--- a/project/events/2026-06-01T20:43:46.113Z__ec80e32c-9d12-4e3c-aa1b-9e886f0c864d.json
+++ b/project/events/2026-06-01T20:43:46.113Z__ec80e32c-9d12-4e3c-aa1b-9e886f0c864d.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "ec80e32c-9d12-4e3c-aa1b-9e886f0c864d",
+  "issue_id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "event_type": "issue_created",
+  "occurred_at": "2026-06-01T20:43:46.113Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "blbs-4130e46d-d9f3-4b30-834e-ba0ab3b13a03",
+    "priority": 1,
+    "status": "open",
+    "title": "Remediate Snyk tar-slip finding in FUNSD sample downloader"
+  }
+}

--- a/project/events/2026-06-01T20:43:50.822Z__a7caa32e-fecb-4463-a4ed-444be5b01357.json
+++ b/project/events/2026-06-01T20:43:50.822Z__a7caa32e-fecb-4463-a4ed-444be5b01357.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a7caa32e-fecb-4463-a4ed-444be5b01357",
+  "issue_id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "event_type": "state_transition",
+  "occurred_at": "2026-06-01T20:43:50.822Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-06-01T20:43:50.823Z__54129662-0681-47d8-b8c9-e9bf3036c52c.json
+++ b/project/events/2026-06-01T20:43:50.823Z__54129662-0681-47d8-b8c9-e9bf3036c52c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "54129662-0681-47d8-b8c9-e9bf3036c52c",
+  "issue_id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "event_type": "comment_added",
+  "occurred_at": "2026-06-01T20:43:50.823Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "2ad3bda3-a8ae-4535-becf-614627f2022c"
+  }
+}

--- a/project/events/2026-06-01T20:44:30.901Z__246c8486-489f-4411-a8ce-86b4573e377f.json
+++ b/project/events/2026-06-01T20:44:30.901Z__246c8486-489f-4411-a8ce-86b4573e377f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "246c8486-489f-4411-a8ce-86b4573e377f",
+  "issue_id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "event_type": "comment_added",
+  "occurred_at": "2026-06-01T20:44:30.901Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "4249a4b4-9613-4967-ba07-86ce746110d2"
+  }
+}

--- a/project/events/2026-06-01T20:44:30.909Z__61b05fa3-3588-4677-84b9-0bbd6cef0a6b.json
+++ b/project/events/2026-06-01T20:44:30.909Z__61b05fa3-3588-4677-84b9-0bbd6cef0a6b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "61b05fa3-3588-4677-84b9-0bbd6cef0a6b",
+  "issue_id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "event_type": "state_transition",
+  "occurred_at": "2026-06-01T20:44:30.909Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/blbs-03a72823-483a-41c5-8c78-ee36185fe000.json
+++ b/project/issues/blbs-03a72823-483a-41c5-8c78-ee36185fe000.json
@@ -1,0 +1,31 @@
+{
+  "id": "blbs-03a72823-483a-41c5-8c78-ee36185fe000",
+  "title": "Remediate Snyk tar-slip finding in FUNSD sample downloader",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "blbs-4130e46d-d9f3-4b30-834e-ba0ab3b13a03",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "2ad3bda3-a8ae-4535-becf-614627f2022c",
+      "author": "derek.norrbom",
+      "text": "Started remediation for Snyk Code tar-slip finding in scripts/download_funsd_samples.py. Reviewing extraction logic and replacing unsafe extraction pattern with safe per-member extraction.",
+      "created_at": "2026-06-01T20:43:50.823778Z"
+    },
+    {
+      "id": "4249a4b4-9613-4967-ba07-86ce746110d2",
+      "author": "derek.norrbom",
+      "text": "Replaced zip extractall() usage with validated per-member extraction in scripts/download_funsd_samples.py. Added absolute/.. path rejection and explicit file copy to destination. Validation: python -m compileall + ruff check pass; snyk code test on script no longer reports findings.",
+      "created_at": "2026-06-01T20:44:30.901036Z"
+    }
+  ],
+  "created_at": "2026-06-01T20:43:46.113009Z",
+  "updated_at": "2026-06-01T20:44:30.908935Z",
+  "closed_at": "2026-06-01T20:44:30.908935Z",
+  "custom": {}
+}

--- a/scripts/download_funsd_samples.py
+++ b/scripts/download_funsd_samples.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -41,10 +42,18 @@ def _extract_zip_safely(zip_path: Path, destination: Path) -> None:
     destination_root = destination.resolve()
     with zipfile.ZipFile(zip_path, "r") as archive:
         for member in archive.infolist():
+            member_path = Path(member.filename)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ValueError(f"Unsafe archive member path: {member.filename}")
             member_target = (destination / member.filename).resolve()
             if destination_root not in member_target.parents and member_target != destination_root:
                 raise ValueError(f"Unsafe archive member path: {member.filename}")
-        archive.extractall(destination)
+            if member.is_dir():
+                member_target.mkdir(parents=True, exist_ok=True)
+                continue
+            member_target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member, "r") as source_file, open(member_target, "wb") as target_file:
+                shutil.copyfileobj(source_file, target_file)
 
 
 def _prepare_corpus(path: Path, *, force: bool) -> Corpus:


### PR DESCRIPTION
**Summary**
- Remediates Snyk Code archive extraction finding in `scripts/download_funsd_samples.py`.
- Replaces `archive.extractall(destination)` with explicit per-member extraction after path validation.
- Rejects archive members with absolute paths or `..` traversal segments.

**Why**
- Prevents arbitrary file write outside the destination directory during dataset extraction.
- Removes use of extraction sink flagged by Snyk Code while preserving script behavior.

**Validation**
- `python -m compileall scripts/download_funsd_samples.py`
- `ruff check scripts/download_funsd_samples.py`
- `snyk code test scripts/download_funsd_samples.py --json`

**Expected Outcome**
- Archive members are extracted only into validated destination paths.
- Tar/zip slip style path traversal writes are blocked.

**Kanbus / Task Tracking**
- `blbs-03a728`
