### PR TITLE
HTML corpus metadata, GROBID pipeline, and graph extraction fixes

### DIFF
--- a/configurations/extraction/ai-ml-research-topic-text.yml
+++ b/configurations/extraction/ai-ml-research-topic-text.yml
@@ -1,0 +1,17 @@
+extractor_id: pipeline
+configuration:
+  stages:
+    - extractor_id: pass-through-text
+      config: {}
+    - extractor_id: grobid-pdf-text
+      config:
+        fallback_to_pypdf: true
+        record_fallback_metadata: true
+    - extractor_id: markitdown
+      config: {}
+    - extractor_id: select-override
+      config:
+        media_type_patterns:
+          - text/html
+          - application/xhtml+xml
+        fallback_to_first: true

--- a/configurations/extraction/ai-ml-research-topic-text.yml
+++ b/configurations/extraction/ai-ml-research-topic-text.yml
@@ -9,6 +9,8 @@ configuration:
         record_fallback_metadata: true
     - extractor_id: markitdown
       config: {}
+    - extractor_id: html-web-metadata
+      config: {}
     - extractor_id: select-override
       config:
         media_type_patterns:

--- a/configurations/graph/ner-entities.yml
+++ b/configurations/graph/ner-entities.yml
@@ -1,4 +1,20 @@
 schema_version: 1
 model: en_core_web_sm
 min_entity_length: 3
+max_entity_length: 120
+entity_labels:
+  - EVENT
+  - FAC
+  - GPE
+  - LANGUAGE
+  - LAW
+  - LOC
+  - NORP
+  - ORG
+  - PER
+  - PRODUCT
+  - WORK_OF_ART
 include_item_node: true
+include_relation_edges: true
+max_relation_entities_per_sentence: 12
+min_relation_weight: 1

--- a/features/html_heuristics.feature
+++ b/features/html_heuristics.feature
@@ -1,0 +1,89 @@
+Feature: HTML heuristic structured extraction
+  Biblicus should extract article metadata and bibliography candidates from HTML using
+  layered heuristics (JSON-LD, Open Graph, meta tags, reference sections, footer links)
+  before optionally falling back to LLM structured extraction.
+
+  Background:
+    Given HTML heuristic fixtures are available
+    And HTML LLM structured extraction is disabled
+
+  Scenario: JSON-LD BlogPosting provides authors and publication date
+    Given I parse the HTML heuristic fixture "synthetic_blog_json_ld.html"
+    Then the heuristic document title is "Understanding Sequence Models"
+    And the heuristic document has at least 2 authors including "Alex Example"
+    And the heuristic document publication date is "2021-03-15"
+    And the heuristic extraction layers include "json_ld"
+    And the heuristic structured payload has at least 2 citations
+
+  Scenario: Open Graph and Twitter card metadata is extracted
+    Given I parse the HTML heuristic fixture "synthetic_news_open_graph.html"
+    Then the heuristic document title is "Corpus Audit Checklist"
+    And the heuristic document has at least 1 authors including "Casey Reviewer"
+    And the heuristic document publication date is "2024-11-02"
+    And the heuristic extraction layers include "open_graph"
+
+  Scenario: Bibliography heading harvests reference list entries
+    Given I parse the HTML heuristic fixture "synthetic_references_only.html"
+    Then the heuristic document has exactly 1 authors including "Dana Writer"
+    And the heuristic structured payload has at least 2 citations
+    And heuristic citation 1 title contains "Baselines for retrieval"
+    And the heuristic extraction layers include "reference_section"
+
+  Scenario: Footer external links become bibliography candidates
+    Given I parse the HTML heuristic fixture "synthetic_footer_links.html"
+    And the heuristic fixture source uri is "https://fixture.test/articles/link-harvest"
+    Then the heuristic document has at least 2 reference candidates
+    And the heuristic extraction layers include "footer_element"
+    And heuristic citation 1 has url "https://example.test/external/paper-a"
+
+  Scenario: Sparse HTML does not satisfy structured sufficiency
+    Given I parse the HTML heuristic fixture "synthetic_sparse.html"
+    Then structured metadata sufficiency is false
+    And the heuristic structured warnings include code "authors_missing"
+
+  Scenario: Heuristic pipeline enriches web extraction without LLM
+    Given I parse the HTML heuristic fixture "synthetic_blog_json_ld.html"
+    And I prepare a web extraction payload with text "Fixture body text"
+  When I enrich the web extraction payload with source uri "https://fixture.test/blog/sequence-models"
+    Then the enriched web extraction method is "html-heuristics"
+    And the enriched structured payload has at least 2 citations
+    And the enriched structured payload has at least 2 authors
+
+  Scenario: LLM fallback runs when heuristics are insufficient and LLM is enabled
+    Given HTML LLM structured extraction is enabled
+    And a fake HTML LLM resolver returns authors and citations for sparse pages
+    And I parse the HTML heuristic fixture "synthetic_sparse.html"
+    And I prepare a web extraction payload with text "Sparse body"
+  When I enrich the web extraction payload with source uri "https://fixture.test/sparse"
+    Then the enriched web extraction method is "llm-html"
+    And the enriched structured payload has at least 1 authors
+    And the enriched structured payload has at least 1 citations
+
+  Scenario: Partial heuristics merge with LLM when sufficiency is not met
+    Given HTML LLM structured extraction is enabled
+    And a fake HTML LLM resolver returns only publication date
+    And I parse the HTML heuristic fixture "synthetic_citations_weak.html"
+    And I prepare a web extraction payload with text "Evaluation body"
+  When I enrich the web extraction payload with source uri "https://fixture.test/eval"
+    Then the enriched web extraction method is "html-heuristics+llm-html"
+    And the enriched structured payload has at least 2 citations
+    And the enriched structured publication date is "2024-01-01"
+
+  Scenario Outline: Reference line parsing extracts years and DOI tokens
+    Given a heuristic reference candidate with raw line "<raw>"
+  When I normalize heuristic reference candidates
+    Then normalized citation 1 year is <year>
+    And normalized citation 1 doi equals <doi>
+
+    Examples:
+      | raw                                                                      | year | doi                    |
+      | Morgan Demo (2018). Attention paper. doi:10.5555/1234567.89              | 2018 | 10.5555/1234567.89     |
+      | Riley Test (2019). Baselines for retrieval benchmarks.                   | 2019 | none                   |
+
+  Scenario: URL text integration uses heuristic HTML when fetch returns HTML
+    Given HTML LLM structured extraction is disabled
+    And the HTML heuristic fixture "synthetic_blog_json_ld.html" is served for uri "https://fixture.test/integration/blog"
+  When I extract URL text from "https://fixture.test/integration/blog"
+    Then the URL text extraction status is "ok"
+    And the URL text extraction method is "html-heuristics"
+    And the URL text structured authors count is at least 2

--- a/features/steps/html_heuristics_steps.py
+++ b/features/steps/html_heuristics_steps.py
@@ -1,0 +1,310 @@
+"""Behave steps for HTML heuristic structured extraction."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from behave import given, then, when
+
+from biblicus.html_heuristics import (
+    _normalize_reference_candidates,
+    extract_html_heuristics,
+    heuristic_document_to_structured,
+    structured_metadata_is_sufficient,
+)
+from biblicus.html_structured_pipeline import enrich_web_extraction_structured
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "html_heuristics"
+
+
+def _fixture_path(name: str) -> Path:
+    return _FIXTURES_DIR / name
+
+
+def _load_fixture(context, filename: str, *, source_uri: str = "https://fixture.test/") -> None:
+    html = _fixture_path(filename).read_text(encoding="utf-8")
+    context._last_fixture_html = html
+    context.current_fixture_name = filename
+    context.heuristic_document = extract_html_heuristics(html, source_uri=source_uri)
+    context.heuristic_structured = heuristic_document_to_structured(context.heuristic_document)
+
+
+@given("HTML heuristic fixtures are available")
+def step_fixtures_available(context) -> None:
+    assert _FIXTURES_DIR.is_dir(), f"Missing fixtures directory: {_FIXTURES_DIR}"
+
+
+@given("HTML LLM structured extraction is disabled")
+def step_disable_llm(context) -> None:
+    os.environ["BIBLICUS_HTML_LLM_STRUCTURED"] = "0"
+    context.html_llm_resolver = None
+
+
+@given("HTML LLM structured extraction is enabled")
+def step_enable_llm(context) -> None:
+    os.environ["BIBLICUS_HTML_LLM_STRUCTURED"] = "1"
+
+
+@given("a fake HTML LLM resolver returns authors and citations for sparse pages")
+def step_fake_llm_sparse(context) -> None:
+    def resolver(*, model: str, messages: list[dict[str, str]]) -> dict[str, Any]:
+        turn = sum(1 for row in messages if row.get("role") == "assistant")
+        if turn == 0:
+            return {"authors": [{"name": "LLM Author", "normalized_name": "author llm"}]}
+        if turn == 1:
+            return {"publication_date": "2024-01-01", "raw": "2024-01-01"}
+        return {
+            "citations": [
+                {
+                    "title": "LLM discovered citation",
+                    "authors": ["Pat Example"],
+                    "year": 2022,
+                    "doi": "10.1000/llm.test",
+                    "citing_context": "Fixture LLM citation context for sparse pages.",
+                }
+            ]
+        }
+
+    context.html_llm_resolver = resolver
+
+
+@given("a fake HTML LLM resolver returns only publication date")
+def step_fake_llm_date_only(context) -> None:
+    def resolver(*, model: str, messages: list[dict[str, str]]) -> dict[str, Any]:
+        turn = sum(1 for row in messages if row.get("role") == "assistant")
+        if turn == 0:
+            return {"authors": []}
+        if turn == 1:
+            return {"publication_date": "2024-01-01", "raw": "2024-01-01"}
+        return {"citations": []}
+
+    context.html_llm_resolver = resolver
+
+
+@given('I parse the HTML heuristic fixture "{filename}"')
+def step_parse_fixture(context, filename: str) -> None:
+    _load_fixture(context, filename)
+
+
+@given('the heuristic fixture source uri is "{source_uri}"')
+def step_set_fixture_source_uri(context, source_uri: str) -> None:
+    filename = getattr(context, "current_fixture_name", None)
+    assert filename, "Parse a fixture before setting source uri"
+    _load_fixture(context, filename, source_uri=source_uri)
+
+
+@given('I prepare a web extraction payload with text "{text}"')
+def step_prepare_web_payload(context, text: str) -> None:
+    html = str(getattr(context, "_last_fixture_html", "") or "")
+    context.web_payload = {
+        "text": text,
+        "markdown": text,
+        "title": None,
+        "html_content": html,
+    }
+
+
+@given('the HTML heuristic fixture "{filename}" is served for uri "{uri}"')
+def step_serve_fixture(context, filename: str, uri: str) -> None:
+    context.served_html = {
+        "uri": uri,
+        "body": _fixture_path(filename).read_text(encoding="utf-8"),
+        "content_type": "text/html",
+    }
+
+
+@when('I enrich the web extraction payload with source uri "{source_uri}"')
+def step_enrich_payload(context, source_uri: str) -> None:
+    payload = dict(context.web_payload)
+    html = str(payload.pop("html_content", "") or "")
+    context.enriched_payload = enrich_web_extraction_structured(
+        payload,
+        source_uri=source_uri,
+        html_content=html,
+        completion_resolver=getattr(context, "html_llm_resolver", None),
+    )
+
+
+@when("I extract URL text from {uri}")
+def step_extract_url_text(context, uri: str) -> None:
+    import biblicus.url_text as url_text_module
+
+    served = getattr(context, "served_html", None)
+    uri = uri.strip('"')
+
+    def fake_fetch(**kwargs):
+        if served and kwargs.get("uri") == served["uri"]:
+            return {
+                "ok": True,
+                "body": served["body"].encode("utf-8"),
+                "content_type": served["content_type"],
+                "final_url": served["uri"],
+                "attempts": [],
+                "error": None,
+            }
+        return {
+            "ok": False,
+            "body": b"",
+            "content_type": None,
+            "final_url": kwargs.get("uri"),
+            "attempts": [],
+            "error": {"code": "not_found", "message": "fixture not served"},
+        }
+
+    def fake_markitdown(**_kwargs):
+        return {
+            "text": "Fixture body from markitdown",
+            "markdown": "Fixture body from markitdown",
+            "title": "Fixture title",
+        }
+
+    original_fetch = url_text_module._fetch_url_bytes
+    original_markitdown = url_text_module._convert_bytes_with_markitdown
+    url_text_module._fetch_url_bytes = fake_fetch
+    url_text_module._convert_bytes_with_markitdown = fake_markitdown
+    try:
+        context.url_text_result = url_text_module.extract_url_text(source_uri=uri)
+    finally:
+        url_text_module._fetch_url_bytes = original_fetch
+        url_text_module._convert_bytes_with_markitdown = original_markitdown
+
+
+@given('a heuristic reference candidate with raw line "{raw}"')
+def step_reference_candidate(context, raw: str) -> None:
+    context.reference_candidates = [{"source": "test", "raw": raw, "title": raw}]
+
+
+@when("I normalize heuristic reference candidates")
+def step_normalize_candidates(context) -> None:
+    context.normalized_citations = _normalize_reference_candidates(context.reference_candidates)
+
+
+@then('the heuristic document title is "{title}"')
+def step_doc_title(context, title: str) -> None:
+    assert context.heuristic_document.title == title
+
+
+def _author_name_from_step(name: str) -> str:
+    return str(name or "").strip().strip('"')
+
+
+@then("the heuristic document has exactly {count:d} authors including {name}")
+def step_doc_authors(context, count: int, name: str) -> None:
+    expected_name = _author_name_from_step(name)
+    names = [row.get("name") for row in context.heuristic_document.authors]
+    assert len(names) == count, f"expected {count} authors, got {names}"
+    assert expected_name in names, f"{expected_name!r} not in {names!r}"
+
+
+@then("the heuristic document has at least {count:d} authors including {name}")
+def step_doc_authors_at_least(context, count: int, name: str) -> None:
+    expected_name = _author_name_from_step(name)
+    names = [row.get("name") for row in context.heuristic_document.authors]
+    assert len(names) >= count, f"expected >={count} authors, got {names!r}"
+    assert expected_name in names, f"{expected_name!r} not in {names!r}"
+
+
+@then('the heuristic document publication date is "{value}"')
+def step_doc_pubdate(context, value: str) -> None:
+    assert context.heuristic_document.publication_date == value
+
+
+@then('the heuristic extraction layers include "{layer}"')
+def step_layers_include(context, layer: str) -> None:
+    assert layer in context.heuristic_document.layers
+
+
+@then("the heuristic structured payload has at least {count:d} citations")
+def step_structured_citations(context, count: int) -> None:
+    citations = context.heuristic_structured.get("citations") or []
+    assert len(citations) >= count
+
+
+@then("heuristic citation {index:d} title contains {text}")
+def step_citation_title_contains(context, index: int, text: str) -> None:
+    needle = _author_name_from_step(text)
+    citation = context.heuristic_structured["citations"][index - 1]
+    title = str(citation.get("title") or "")
+    assert needle in title, f"expected {needle!r} in citation title {title!r}"
+
+
+@then('heuristic citation {index:d} has url "{url}"')
+def step_citation_url(context, index: int, url: str) -> None:
+    citation = context.heuristic_structured["citations"][index - 1]
+    assert citation.get("url") == url
+
+
+@then("the heuristic document has at least {count:d} reference candidates")
+def step_ref_candidates(context, count: int) -> None:
+    assert len(context.heuristic_document.reference_candidates) >= count
+
+
+@then("structured metadata sufficiency is false")
+def step_not_sufficient(context) -> None:
+    assert structured_metadata_is_sufficient(context.heuristic_structured) is False
+
+
+@then('the heuristic structured warnings include code "{code}"')
+def step_warning_code(context, code: str) -> None:
+    warnings = context.heuristic_structured.get("warnings") or []
+    assert any(str(row.get("code") or "") == code for row in warnings)
+
+
+@then('the enriched web extraction method is "{method}"')
+def step_enriched_method(context, method: str) -> None:
+    assert context.enriched_payload.get("method") == method
+
+
+@then("the enriched structured payload has at least {count:d} citations")
+def step_enriched_citations(context, count: int) -> None:
+    structured = context.enriched_payload.get("structured") or {}
+    assert len(structured.get("citations") or []) >= count
+
+
+@then("the enriched structured payload has at least {count:d} authors")
+def step_enriched_authors(context, count: int) -> None:
+    structured = context.enriched_payload.get("structured") or {}
+    assert len(structured.get("authors") or []) >= count
+
+
+@then('the enriched structured publication date is "{value}"')
+def step_enriched_pubdate(context, value: str) -> None:
+    structured = context.enriched_payload.get("structured") or {}
+    assert structured.get("publication_date") == value
+
+
+@then("normalized citation {index:d} year is {year}")
+def step_norm_year(context, index: int, year: str) -> None:
+    citation = context.normalized_citations[index - 1]
+    if not year.strip():
+        assert citation.get("year") is None
+    else:
+        assert citation.get("year") == int(year)
+
+
+@then("normalized citation {index:d} doi equals {doi}")
+def step_norm_doi(context, index: int, doi: str) -> None:
+    citation = context.normalized_citations[index - 1]
+    expected = doi.strip()
+    if not expected or expected.lower() == "none":
+        assert not citation.get("doi")
+    else:
+        assert citation.get("doi") == expected
+
+
+@then('the URL text extraction status is "{status}"')
+def step_url_status(context, status: str) -> None:
+    assert context.url_text_result.get("status") == status
+
+
+@then('the URL text extraction method is "{method}"')
+def step_url_method(context, method: str) -> None:
+    assert context.url_text_result.get("method") == method
+
+
+@then("the URL text structured authors count is at least {count:d}")
+def step_url_authors(context, count: int) -> None:
+    structured = context.url_text_result.get("structured") or {}
+    assert len(structured.get("authors") or []) >= count

--- a/features/steps/text_internal_steps.py
+++ b/features/steps/text_internal_steps.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from behave import then, when
 
-from biblicus.text.extract import _extract_validation_error_from_messages
+from biblicus.text.extract import _extract_latest_failure_error_from_messages as _extract_validation_error_from_messages
 from biblicus.text.tool_loop import _build_no_tool_calls_message
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ paddleocr = [
 markitdown = [
   "markitdown[all]>=0.1.0; python_version>='3.10' and python_version<'3.14'",
 ]
+web = [
+  "beautifulsoup4>=4.12",
+]
 deepgram = [
   "deepgram-sdk>=3.0",
 ]

--- a/scripts/analyze_local_entity_graph.py
+++ b/scripts/analyze_local_entity_graph.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Summarize a local ner-entities graph export for quality review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def _load_export(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _entity_nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    nodes = payload.get("nodes") or []
+    return [n for n in nodes if str(n.get("node_type") or "") == "entity"]
+
+
+def _person_like(label: str) -> bool:
+    if not label or len(label) > 80:
+        return False
+    if re.search(r"\d", label):
+        return False
+    parts = label.split()
+    if len(parts) == 1:
+        return bool(re.match(r"^[A-Z][a-z'\-]+$", parts[0]))
+    if 1 < len(parts) <= 4:
+        return all(re.match(r"^[A-Z][A-Za-z'\-]+$", p) for p in parts)
+    return False
+
+
+def analyze(payload: dict[str, Any]) -> dict[str, Any]:
+    entities = _entity_nodes(payload)
+    edges = payload.get("edges") or []
+    by_type = Counter(
+        str((n.get("properties") or {}).get("entity_type") or "UNKNOWN") for n in entities
+    )
+    mention_edges = [e for e in edges if str(e.get("edge_type") or "") == "mentions"]
+    relation_edges = [e for e in edges if str(e.get("edge_type") or "") == "related_to"]
+    labels = [str(n.get("label") or "") for n in entities]
+    person_like = [label for label in labels if _person_like(label)]
+    top = Counter(labels).most_common(30)
+    per_labels = [
+        str(n.get("label") or "")
+        for n in entities
+        if str((n.get("properties") or {}).get("entity_type") or "") == "PER"
+    ]
+    return {
+        "entity_count": len(entities),
+        "mention_edge_count": len(mention_edges),
+        "related_to_edge_count": len(relation_edges),
+        "entity_types": dict(by_type.most_common()),
+        "person_like_count": len(person_like),
+        "person_like_fraction": round(len(person_like) / max(len(entities), 1), 4),
+        "per_entity_count": len(per_labels),
+        "top_entities": top,
+        "sample_per": sorted(set(per_labels))[:40],
+        "sample_person_like": sorted(set(person_like))[:40],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("export_json", type=Path, help="Path to graph export JSON")
+    parser.add_argument("--output", type=Path, default=None, help="Write summary JSON here")
+    args = parser.parse_args()
+    summary = analyze(_load_export(args.export_json))
+    text = json.dumps(summary, indent=2)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+        print(f"wrote {args.output}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnose_grobid_extraction.py
+++ b/scripts/diagnose_grobid_extraction.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Probe GROBID extraction health on a sample of corpus PDFs.
+
+Auto-starts local GROBID via Docker when needed (same as corpus extraction).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from biblicus.grobid_runtime import ensure_grobid_running
+from biblicus.url_text import UrlTextExtractionError, _convert_pdf_with_grobid
+
+
+def _probe_one(*, root: Path, item: dict) -> tuple[str, float, str | None]:
+    path = root / item["relpath"]
+    started = time.perf_counter()
+    try:
+        payload = _convert_pdf_with_grobid(
+            data=path.read_bytes(),
+            source_uri=str(path),
+            content_type=item.get("media_type"),
+        )
+        text = str(payload.get("text") or "").strip()
+        if not text:
+            return "empty", time.perf_counter() - started, None
+        structured = payload.get("structured") if isinstance(payload.get("structured"), dict) else {}
+        authors = len(structured.get("authors") or [])
+        return "ok", time.perf_counter() - started, f"authors={authors}"
+    except UrlTextExtractionError as exc:
+        return exc.code, time.perf_counter() - started, exc.message
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", default="corpora/AI-ML-research")
+    parser.add_argument("--sample-size", type=int, default=12)
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args()
+
+    root = Path(args.corpus)
+    ensure_grobid_running()
+    catalog = json.loads((root / "metadata" / "catalog.json").read_text(encoding="utf-8"))
+    items = [value for value in catalog["items"].values() if value.get("media_type") == "application/pdf"]
+    if not items:
+        raise SystemExit("No PDF items found in catalog.")
+    sample = random.Random(args.seed).sample(items, min(args.sample_size, len(items)))
+
+    results: list[tuple[str, float, str | None]] = []
+    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as executor:
+        futures = [
+            executor.submit(_probe_one, root=root, item=item)
+            for item in sample
+        ]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    status_counts = Counter(status for status, _elapsed, _detail in results)
+    error_codes = Counter(status for status, _elapsed, _detail in results if status not in {"ok", "empty"})
+    avg_seconds = sum(elapsed for _status, elapsed, _detail in results) / max(len(results), 1)
+    summary = {
+        "sample_size": len(results),
+        "workers": args.workers,
+        "status_counts": dict(status_counts),
+        "error_codes": dict(error_codes),
+        "avg_seconds": round(avg_seconds, 2),
+        "recommendation": (
+            "GROBID looks healthy for a small sample."
+            if status_counts.get("ok", 0) >= max(1, len(results) // 2)
+            else "GROBID is failing for most samples — fix service health before corpus rebuild."
+        ),
+    }
+    print(json.dumps(summary, indent=2))
+    return 0 if status_counts.get("ok", 0) > 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_entity_graph_rebuild.sh
+++ b/scripts/local_entity_graph_rebuild.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Local bankruptcy rebuild: purge entity graphs, re-extract with GROBID, rebuild NER graph.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CORPUS="${CORPUS:-$ROOT/corpora/AI-ML-research}"
+export BIBLICUS_GROBID_URL="${BIBLICUS_GROBID_URL:-http://127.0.0.1:8070}"
+export BIBLICUS_GROBID_MAX_CONCURRENT="${BIBLICUS_GROBID_MAX_CONCURRENT:-2}"
+export BIBLICUS_GROBID_MAX_RETRIES="${BIBLICUS_GROBID_MAX_RETRIES:-3}"
+export EXTRACT_MAX_WORKERS="${EXTRACT_MAX_WORKERS:-2}"
+export PYTHONPATH="${ROOT}/src:${PYTHONPATH:-}"
+LOG_DIR="${LOG_DIR:-/tmp/biblicus-entity-rebuild}"
+mkdir -p "$LOG_DIR"
+
+cd "$ROOT"
+
+echo "==> GROBID JIT auto-start enabled (Docker on localhost; sample probe)"
+python3 scripts/diagnose_grobid_extraction.py --corpus "$CORPUS" --sample-size 8 --workers "$BIBLICUS_GROBID_MAX_CONCURRENT" \
+  || { echo "GROBID probe failed after auto-start attempt." >&2; exit 1; }
+
+echo "==> Purging local entity graph artifacts"
+python3 scripts/purge_local_entity_graph.py --corpus "$CORPUS"
+
+echo "==> Rebuilding text extraction snapshot (GROBID PDF + pipeline)"
+python3 -m biblicus extract build \
+  --corpus "$CORPUS" \
+  --configuration-name ai-ml-research-topic-text \
+  --configuration configurations/extraction/ai-ml-research-topic-text.yml \
+  --force \
+  --max-workers "${EXTRACT_MAX_WORKERS:-4}" \
+  2>&1 | tee "$LOG_DIR/extract-build.log"
+
+SNAPSHOT="$(python3 -c "
+import json, subprocess
+out = subprocess.check_output(['python3','-m','biblicus','extract','list','--corpus', '$CORPUS'], text=True)
+entries = json.loads(out)
+pipe = next(e for e in entries if e.get('extractor_id')=='pipeline')
+print(f\"pipeline:{pipe['snapshot_id']}\")
+")"
+echo "==> Using extraction snapshot $SNAPSHOT"
+
+echo "==> Building ner-entities graph snapshot"
+python3 -m biblicus graph extract \
+  --corpus "$CORPUS" \
+  --extractor ner-entities \
+  --configuration-name ner-entities \
+  --configuration configurations/graph/ner-entities.yml \
+  --extraction-snapshot "$SNAPSHOT" \
+  --item-timeout-seconds 120 \
+  2>&1 | tee "$LOG_DIR/graph-extract.log"
+
+GRAPH_SNAP="$(python3 -c "
+import json, subprocess
+out = subprocess.check_output(['python3','-m','biblicus','graph','list','--corpus', '$CORPUS', '--extractor-id', 'ner-entities'], text=True)
+latest = json.loads(out)[0]
+print(f\"ner-entities:{latest['snapshot_id']}\")
+")"
+EXPORT="$LOG_DIR/graph-export.json"
+echo "==> Exporting $GRAPH_SNAP to $EXPORT"
+python3 -m biblicus graph export \
+  --corpus "$CORPUS" \
+  --snapshot "$GRAPH_SNAP" \
+  --output "$EXPORT"
+
+SUMMARY="$LOG_DIR/entity-summary.json"
+echo "==> Analysis summary -> $SUMMARY"
+python3 scripts/analyze_local_entity_graph.py "$EXPORT" --output "$SUMMARY"
+echo "Done. Export: $EXPORT  Summary: $SUMMARY"

--- a/scripts/pilot_grobid_pipeline.py
+++ b/scripts/pilot_grobid_pipeline.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Pilot GROBID pipeline extraction on a sample of PDFs and report quality signals.
+
+Does not run graph extraction — use this to tune text/GROBID behavior before full rebuilds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+from biblicus.configuration import load_configuration_view
+from biblicus.corpus import Corpus
+from biblicus.extractors import get_extractor
+from biblicus.extractors.pipeline import PipelineExtractorConfig
+from biblicus.grobid_runtime import ensure_grobid_running
+from biblicus.models import ExtractionStageOutput
+
+
+def _load_pipeline_stages(config_path: Path) -> list[tuple[str, dict[str, Any]]]:
+    data = load_configuration_view(
+        [str(config_path)],
+        configuration_label="extraction config",
+        mapping_error_message="expected mapping",
+    )
+    stages = data.get("configuration", data).get("stages", [])
+    if not isinstance(stages, list):
+        raise ValueError("pipeline stages missing")
+    parsed: list[tuple[str, dict[str, Any]]] = []
+    for stage in stages:
+        parsed.append((str(stage["extractor_id"]), dict(stage.get("config") or {})))
+    return parsed
+
+
+def _run_pipeline_for_item(
+    *,
+    corpus: Corpus,
+    item,
+    stages: list[tuple[str, dict[str, Any]]],
+) -> dict[str, Any]:
+    stage_outputs: list[ExtractionStageOutput] = []
+    stage_summaries: list[dict[str, Any]] = []
+    for stage_index, (extractor_id, stage_config) in enumerate(stages, start=1):
+        extractor = get_extractor(extractor_id)
+        parsed_config = extractor.validate_config(stage_config)
+        started = time.perf_counter()
+        try:
+            extracted = extractor.extract_text(
+                corpus=corpus,
+                item=item,
+                config=parsed_config,
+                previous_extractions=stage_outputs,
+            )
+        except Exception as exc:
+            return {
+                "item_id": item.id,
+                "relpath": item.relpath,
+                "status": "errored",
+                "error": f"{exc.__class__.__name__}: {exc}",
+                "stages": stage_summaries,
+            }
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        if extracted is None:
+            stage_summaries.append(
+                {
+                    "stage_index": stage_index,
+                    "extractor_id": extractor_id,
+                    "status": "skipped",
+                    "elapsed_ms": elapsed_ms,
+                }
+            )
+            continue
+        method = str((extracted.metadata or {}).get("method") or "")
+        stage_summaries.append(
+            {
+                "stage_index": stage_index,
+                "extractor_id": extractor_id,
+                "status": "extracted",
+                "producer": extracted.producer_extractor_id,
+                "method": method or None,
+                "text_chars": len(extracted.text or ""),
+                "elapsed_ms": elapsed_ms,
+                "grobid_error": (extracted.metadata or {}).get("grobid_fallback"),
+            }
+        )
+        stage_outputs.append(
+            ExtractionStageOutput(
+                stage_index=stage_index,
+                extractor_id=extractor_id,
+                status="extracted",
+                text=extracted.text,
+                text_characters=len(extracted.text or ""),
+                producer_extractor_id=extracted.producer_extractor_id,
+                source_stage_index=extracted.source_stage_index,
+                confidence=extracted.confidence,
+                metadata=dict(extracted.metadata or {}),
+                error_type=None,
+                error_message=None,
+            )
+        )
+    if not stage_outputs:
+        return {
+            "item_id": item.id,
+            "relpath": item.relpath,
+            "status": "skipped",
+            "stages": stage_summaries,
+        }
+    select_stage = stages[-1]
+    if select_stage[0] == "select-override":
+        selector = get_extractor("select-override")
+        select_config = selector.validate_config(select_stage[1])
+        selected = selector.extract_text(
+            corpus=corpus,
+            item=item,
+            config=select_config,
+            previous_extractions=stage_outputs,
+        )
+        if selected is None:
+            return {
+                "item_id": item.id,
+                "relpath": item.relpath,
+                "status": "skipped",
+                "stages": stage_summaries,
+            }
+        final_meta = dict(selected.metadata or {})
+        return {
+            "item_id": item.id,
+            "relpath": item.relpath,
+            "status": "extracted",
+            "final_producer": selected.producer_extractor_id,
+            "final_method": final_meta.get("method"),
+            "text_chars": len(selected.text or ""),
+            "authors": len((final_meta.get("structured") or {}).get("authors") or []),
+            "citations": len((final_meta.get("structured") or {}).get("citations") or []),
+            "grobid_fallback": final_meta.get("grobid_fallback"),
+            "stages": stage_summaries,
+        }
+    final = stage_outputs[-1]
+    final_meta = dict(final.metadata or {})
+    return {
+        "item_id": item.id,
+        "relpath": item.relpath,
+        "status": "extracted",
+        "final_producer": final.producer_extractor_id,
+        "final_method": final_meta.get("method"),
+        "text_chars": len(final.text or ""),
+        "authors": len((final_meta.get("structured") or {}).get("authors") or []),
+        "citations": len((final_meta.get("structured") or {}).get("citations") or []),
+        "grobid_fallback": final_meta.get("grobid_fallback"),
+        "stages": stage_summaries,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", default="corpora/AI-ML-research")
+    parser.add_argument(
+        "--configuration",
+        default="configurations/extraction/ai-ml-research-topic-text.yml",
+    )
+    parser.add_argument("--sample-size", type=int, default=25)
+    parser.add_argument("--seed", type=int, default=11)
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Parallel items (simulates extract build worker pool).",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    ensure_grobid_running()
+    corpus = Corpus.open(args.corpus)
+    catalog = corpus.load_catalog()
+    pdf_items = [
+        corpus.get_item(item_id)
+        for item_id, entry in catalog.items.items()
+        if entry.media_type == "application/pdf"
+    ]
+    sample = random.Random(args.seed).sample(pdf_items, min(args.sample_size, len(pdf_items)))
+    stages = _load_pipeline_stages(Path(args.configuration))
+
+    results: list[dict[str, Any]] = []
+    started = time.perf_counter()
+    workers = max(1, int(args.workers))
+
+    def _run_one(item) -> dict[str, Any]:
+        return _run_pipeline_for_item(corpus=corpus, item=item, stages=stages)
+
+    if workers == 1:
+        for index, item in enumerate(sample, start=1):
+            print(f"[pilot] {index}/{len(sample)} {item.relpath}", flush=True)
+            results.append(_run_one(item))
+    else:
+        print(f"[pilot] running {len(sample)} items with {workers} workers", flush=True)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(_run_one, item): item for item in sample}
+            done = 0
+            for future in as_completed(futures):
+                done += 1
+                item = futures[future]
+                row = future.result()
+                results.append(row)
+                print(
+                    f"[pilot] {done}/{len(sample)} {item.relpath} method={row.get('final_method')}",
+                    flush=True,
+                )
+
+    methods = Counter(row.get("final_method") or "none" for row in results if row.get("status") == "extracted")
+    fallbacks = [
+        row
+        for row in results
+        if row.get("final_method") == "pypdf-fallback" or row.get("grobid_fallback")
+    ]
+    grobid_ok = [
+        row
+        for row in results
+        if row.get("final_method") == "grobid" and row.get("text_chars", 0) > 0
+    ]
+    summary = {
+        "sample_size": len(sample),
+        "elapsed_seconds": round(time.perf_counter() - started, 1),
+        "status_counts": dict(Counter(row.get("status") for row in results)),
+        "final_methods": dict(methods),
+        "grobid_success": len(grobid_ok),
+        "pypdf_fallback": len(fallbacks),
+        "grobid_success_rate": round(len(grobid_ok) / max(len(sample), 1), 3),
+        "avg_authors": round(
+            sum(row.get("authors", 0) for row in grobid_ok) / max(len(grobid_ok), 1),
+            1,
+        ),
+        "avg_citations": round(
+            sum(row.get("citations", 0) for row in grobid_ok) / max(len(grobid_ok), 1),
+            1,
+        ),
+        "fallback_samples": [
+            {
+                "relpath": row.get("relpath"),
+                "grobid_fallback": row.get("grobid_fallback"),
+            }
+            for row in fallbacks[:8]
+        ],
+        "items": results,
+    }
+    output_path = args.output or Path("/tmp/biblicus-grobid-pilot.json")
+    output_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({k: v for k, v in summary.items() if k != "items"}, indent=2))
+    print(f"wrote {output_path}")
+    return 0 if len(grobid_ok) >= max(1, len(sample) // 2) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pilot_html_llm_pipeline.py
+++ b/scripts/pilot_html_llm_pipeline.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Pilot LLM HTML structured extraction on sample web URLs.
+
+Reports method, structured summary, warnings, and timing per URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import Any
+
+from biblicus.url_text import extract_url_text
+
+
+DEFAULT_URLS = [
+    "https://arxiv.org/abs/1706.03762",
+    "https://distill.pub/2017/feature-visualization/",
+    "https://jalammar.github.io/illustrated-transformer/",
+    "https://lilianweng.github.io/posts/2018-06-24-attention/",
+    "https://openai.com/research/attention-is-all-you-need",
+]
+
+
+def _summarize_structured(structured: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(structured, dict):
+        return {}
+    authors = structured.get("authors") if isinstance(structured.get("authors"), list) else []
+    citations = structured.get("citations") if isinstance(structured.get("citations"), list) else []
+    with_context = sum(
+        1
+        for row in citations
+        if isinstance(row, dict) and str(row.get("citing_context") or "").strip()
+    )
+    return {
+        "authors_count": len(authors),
+        "author_names": [str(a.get("name") or "") for a in authors[:5] if isinstance(a, dict)],
+        "publication_date": structured.get("publication_date"),
+        "citations_count": len(citations),
+        "citations_with_citing_context": with_context,
+        "citation_titles_sample": [
+            str(row.get("title") or row.get("raw") or "")[:80]
+            for row in citations[:5]
+            if isinstance(row, dict)
+        ],
+        "warnings": structured.get("warnings") if isinstance(structured.get("warnings"), list) else [],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pilot LLM HTML structured URL extraction")
+    parser.add_argument("--url", action="append", dest="urls", help="URL to extract (repeatable)")
+    parser.add_argument("--output", default="", help="Optional JSON output path")
+    args = parser.parse_args()
+    urls = args.urls or DEFAULT_URLS
+
+    rows: list[dict[str, Any]] = []
+    for url in urls:
+        started = time.perf_counter()
+        row: dict[str, Any] = {"url": url}
+        try:
+            result = extract_url_text(source_uri=url)
+            elapsed = time.perf_counter() - started
+            row.update(
+                {
+                    "status": result.get("status"),
+                    "source_kind": result.get("source_kind"),
+                    "method": result.get("method"),
+                    "text_length": len(str(result.get("text") or "")),
+                    "title": result.get("title"),
+                    "elapsed_seconds": round(elapsed, 2),
+                    "structured_summary": _summarize_structured(
+                        result.get("structured") if isinstance(result.get("structured"), dict) else None
+                    ),
+                    "error": result.get("error"),
+                    "llm_warnings": result.get("llm_structured_warnings"),
+                }
+            )
+        except Exception as exc:
+            row.update(
+                {
+                    "status": "exception",
+                    "elapsed_seconds": round(time.perf_counter() - started, 2),
+                    "error": f"{exc.__class__.__name__}: {exc}",
+                }
+            )
+        rows.append(row)
+        print(json.dumps(row, indent=2, ensure_ascii=False))
+        print("---")
+
+    summary = {
+        "total": len(rows),
+        "ok": sum(1 for row in rows if row.get("status") == "ok"),
+        "llm_html": sum(1 for row in rows if row.get("method") == "llm-html"),
+        "with_authors": sum(1 for row in rows if (row.get("structured_summary") or {}).get("authors_count")),
+        "with_citations": sum(1 for row in rows if (row.get("structured_summary") or {}).get("citations_count")),
+        "with_citing_context": sum(
+            1
+            for row in rows
+            if (row.get("structured_summary") or {}).get("citations_with_citing_context")
+        ),
+    }
+    print("SUMMARY", json.dumps(summary, indent=2))
+
+    if args.output:
+        payload = {"summary": summary, "rows": rows}
+        with open(args.output, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+        print(f"wrote {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/purge_local_entity_graph.py
+++ b/scripts/purge_local_entity_graph.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Purge local Biblicus entity graph artifacts for a corpus (Neo4j + snapshot dirs).
+
+Does not touch cloud / Papyrus production records.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from biblicus.corpus import Corpus
+from biblicus.graph.neo4j import create_neo4j_driver, resolve_neo4j_settings
+
+
+def _purge_neo4j(*, corpus_uri: str, dry_run: bool) -> int:
+    settings = resolve_neo4j_settings()
+    driver = create_neo4j_driver(settings)
+    try:
+        with driver.session(database=settings.database) as session:
+            count = session.run(
+                """
+                MATCH (n:GraphNode {corpus_id: $corpus_id})
+                RETURN count(n) AS c
+                """,
+                corpus_id=corpus_uri,
+            ).single()["c"]
+            if dry_run:
+                print(f"[dry-run] would delete {count} GraphNode rows for corpus_id={corpus_uri!r}")
+                return count
+            session.run(
+                """
+                MATCH (n:GraphNode {corpus_id: $corpus_id})
+                DETACH DELETE n
+                """,
+                corpus_id=corpus_uri,
+            )
+            print(f"deleted {count} GraphNode rows for corpus_id={corpus_uri!r}")
+            return count
+    finally:
+        driver.close()
+
+
+def _purge_snapshot_dirs(*, graph_dir: Path, extractors: list[str], dry_run: bool) -> None:
+    for extractor_id in extractors:
+        extractor_dir = graph_dir / extractor_id
+        if not extractor_dir.is_dir():
+            print(f"skip missing {extractor_dir}")
+            continue
+        for child in extractor_dir.iterdir():
+            if child.name == "latest.json":
+                continue
+            if child.is_dir():
+                if dry_run:
+                    print(f"[dry-run] would remove {child}")
+                else:
+                    shutil.rmtree(child)
+                    print(f"removed {child}")
+        latest = extractor_dir / "latest.json"
+        if latest.is_file() and not dry_run:
+            latest.unlink()
+            print(f"removed {latest}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus",
+        default="corpora/AI-ML-research",
+        help="Corpus path (default: corpora/AI-ML-research)",
+    )
+    parser.add_argument(
+        "--extractor",
+        action="append",
+        default=["ner-entities", "simple-entities"],
+        help="Graph extractor snapshot dirs to purge (repeatable)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    corpus = Corpus.open(args.corpus)
+    corpus_uri = corpus.uri
+    graph_dir = corpus.root / "graph"
+    _purge_neo4j(corpus_uri=corpus_uri, dry_run=args.dry_run)
+    _purge_snapshot_dirs(graph_dir=graph_dir, extractors=list(args.extractor), dry_run=args.dry_run)
+  # Drop stale local export bundles under analysis/ if present
+    analysis_exports = corpus.root / "analysis" / "graph-exports"
+    if analysis_exports.is_dir():
+        for child in analysis_exports.iterdir():
+            if dry_run:
+                print(f"[dry-run] would remove {child}")
+            else:
+                shutil.rmtree(child) if child.is_dir() else child.unlink()
+                print(f"removed {child}")
+    print(json.dumps({"corpus_uri": corpus_uri, "status": "purged" if not args.dry_run else "dry-run"}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/biblicus/cli.py
+++ b/src/biblicus/cli.py
@@ -992,6 +992,94 @@ def cmd_extract_delete(arguments: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_extract_web_metadata(arguments: argparse.Namespace) -> int:
+    """
+    Extract reference metadata (title, authors, dates) from web HTML heuristics.
+
+    :param arguments: Parsed command-line interface arguments.
+    :type arguments: argparse.Namespace
+    :return: Exit code.
+    :rtype: int
+    """
+    from .url_text import URL_TEXT_DEFAULT_TIMEOUT_SECONDS, load_url_text_input_json
+    from .web_reference_metadata import (
+        extract_web_reference_metadata_from_html,
+        extract_web_reference_metadata_from_url,
+    )
+
+    try:
+        payload = load_url_text_input_json(arguments.input_json)
+    except ValueError as exc:
+        print(
+            json.dumps(
+                {
+                    "status": "failed",
+                    "error": {"code": "invalid_input_json", "message": str(exc)},
+                },
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    source_uri = str(payload.get("source_uri") or "").strip()
+    html_content = str(payload.get("html_content") or payload.get("html") or "").strip()
+    use_llm_fallback = bool(payload.get("use_llm_fallback"))
+    reference_title = str(payload.get("reference_title") or "")
+
+    try:
+        if html_content:
+            from .web_reference_metadata import LOCAL_HTML_SOURCE_URI
+
+            output = extract_web_reference_metadata_from_html(
+                html_content,
+                source_uri=source_uri or LOCAL_HTML_SOURCE_URI,
+                reference_title=reference_title,
+                use_llm_fallback=use_llm_fallback,
+                model=str(payload.get("model") or ""),
+            )
+        elif source_uri:
+            output = extract_web_reference_metadata_from_url(
+                source_uri,
+                reference_title=reference_title,
+                use_llm_fallback=use_llm_fallback,
+                model=str(payload.get("model") or ""),
+                timeout_seconds=float(
+                    payload.get("timeout_seconds") or URL_TEXT_DEFAULT_TIMEOUT_SECONDS
+                ),
+            )
+        else:
+            print(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "error": {
+                            "code": "missing_input",
+                            "message": "Provide source_uri and/or html_content.",
+                        },
+                    },
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+            return 2
+    except ValueError as exc:
+        print(
+            json.dumps(
+                {
+                    "status": "failed",
+                    "error": {"code": "web_metadata_failed", "message": str(exc)},
+                },
+                indent=2,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    print(json.dumps({"status": "ok", **output}, indent=2))
+    return 0
+
+
 def cmd_extract_evaluate(arguments: argparse.Namespace) -> int:
     """
     Evaluate an extraction snapshot against a dataset.
@@ -2007,6 +2095,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Type the exact extractor_id:snapshot_id to confirm deletion.",
     )
     p_extract_delete.set_defaults(func=cmd_extract_delete)
+
+    p_extract_web_metadata = extract_sub.add_parser(
+        "web-metadata",
+        help="Extract title, authors, and bibliography metadata from web HTML.",
+    )
+    p_extract_web_metadata.add_argument(
+        "--input-json",
+        default="-",
+        help="JSON payload with source_uri and/or html_content (default: stdin).",
+    )
+    p_extract_web_metadata.add_argument(
+        "--use-llm-fallback",
+        action="store_true",
+        help="Run LLM structured enrichment when heuristics are sparse.",
+    )
+    p_extract_web_metadata.set_defaults(func=cmd_extract_web_metadata)
 
     p_extract_evaluate = extract_sub.add_parser(
         "evaluate", help="Evaluate an extraction snapshot against a dataset."

--- a/src/biblicus/extraction.py
+++ b/src/biblicus/extraction.py
@@ -736,7 +736,13 @@ def build_extraction_snapshot(
                         encoding="utf-8",
                     )
 
-        if not force and final_text_path.is_file():
+        metadata_path = snapshot_dir / final_metadata_relpath
+        html_needs_metadata = (
+            media_type.startswith("text/html")
+            and final_text_path.is_file()
+            and not metadata_path.is_file()
+        )
+        if not force and final_text_path.is_file() and not html_needs_metadata:
             final_text_value = final_text_path.read_text(encoding="utf-8")
             cached_item = previous_items.get(item.id)
             if cached_item and cached_item.final_stage_extractor_id:

--- a/src/biblicus/extractors/__init__.py
+++ b/src/biblicus/extractors/__init__.py
@@ -17,6 +17,7 @@ from .docling_granite_text import DoclingGraniteExtractor
 from .docling_smol_text import DoclingSmolExtractor
 from .faster_whisper_stt import FasterWhisperSpeechToTextExtractor
 from .google_speech_stt import GoogleSpeechToTextExtractor
+from .grobid_pdf_text import GrobidPortableDocumentFormatTextExtractor
 from .heron_layout import HeronLayoutExtractor
 from .markitdown_text import MarkItDownExtractor
 from .metadata_text import MetadataTextExtractor
@@ -56,6 +57,7 @@ def get_extractor(extractor_id: str) -> TextExtractor:
         PassThroughTextExtractor.extractor_id: PassThroughTextExtractor(),
         PipelineExtractor.extractor_id: PipelineExtractor(),
         PortableDocumentFormatTextExtractor.extractor_id: PortableDocumentFormatTextExtractor(),
+        GrobidPortableDocumentFormatTextExtractor.extractor_id: GrobidPortableDocumentFormatTextExtractor(),
         OpenAiSpeechToTextExtractor.extractor_id: OpenAiSpeechToTextExtractor(),
         OpenAiAudioSpeechToTextExtractor.extractor_id: OpenAiAudioSpeechToTextExtractor(),
         FasterWhisperSpeechToTextExtractor.extractor_id: FasterWhisperSpeechToTextExtractor(),

--- a/src/biblicus/extractors/__init__.py
+++ b/src/biblicus/extractors/__init__.py
@@ -19,6 +19,7 @@ from .faster_whisper_stt import FasterWhisperSpeechToTextExtractor
 from .google_speech_stt import GoogleSpeechToTextExtractor
 from .grobid_pdf_text import GrobidPortableDocumentFormatTextExtractor
 from .heron_layout import HeronLayoutExtractor
+from .html_web_metadata import HtmlWebMetadataExtractor
 from .markitdown_text import MarkItDownExtractor
 from .metadata_text import MetadataTextExtractor
 from .mock_layout_detector import MockLayoutDetectorExtractor
@@ -52,6 +53,7 @@ def get_extractor(extractor_id: str) -> TextExtractor:
         MetadataTextExtractor.extractor_id: MetadataTextExtractor(),
         MockLayoutDetectorExtractor.extractor_id: MockLayoutDetectorExtractor(),
         MarkItDownExtractor.extractor_id: MarkItDownExtractor(),
+        HtmlWebMetadataExtractor.extractor_id: HtmlWebMetadataExtractor(),
         DoclingSmolExtractor.extractor_id: DoclingSmolExtractor(),
         DoclingGraniteExtractor.extractor_id: DoclingGraniteExtractor(),
         PassThroughTextExtractor.extractor_id: PassThroughTextExtractor(),

--- a/src/biblicus/extractors/grobid_pdf_text.py
+++ b/src/biblicus/extractors/grobid_pdf_text.py
@@ -22,12 +22,28 @@ class GrobidPortableDocumentFormatTextExtractorConfig(BaseModel):
     :vartype max_pages: int or None
     :ivar fallback_to_pypdf: Use pypdf when GROBID is unavailable.
     :vartype fallback_to_pypdf: bool
+    :ivar record_fallback_metadata: Persist metadata when falling back to pypdf.
+    :vartype record_fallback_metadata: bool
     """
 
     model_config = ConfigDict(extra="forbid")
 
     max_pages: Optional[int] = Field(default=None, ge=1)
     fallback_to_pypdf: bool = Field(default=True)
+    record_fallback_metadata: bool = Field(default=True)
+
+
+def _empty_structured_payload(*, warnings: List[Dict[str, str]]) -> Dict[str, Any]:
+    return {
+        "authors": [],
+        "citations": [],
+        "summary": {
+            "authors_count": 0,
+            "citations_count": 0,
+            "citations_with_identifiers": 0,
+        },
+        "warnings": warnings,
+    }
 
 
 class GrobidPortableDocumentFormatTextExtractor(TextExtractor):
@@ -86,22 +102,32 @@ class GrobidPortableDocumentFormatTextExtractor(TextExtractor):
                 source_uri=str(pdf_path),
                 content_type=item.media_type,
             )
-        except UrlTextExtractionError:
+        except UrlTextExtractionError as exc:
             if not parsed.fallback_to_pypdf:
                 raise
-            fallback = PortableDocumentFormatTextExtractor()
-            fallback_result = fallback.extract_text(
+            return self._fallback_extract(
                 corpus=corpus,
                 item=item,
-                config=PortableDocumentFormatTextExtractorConfig(max_pages=parsed.max_pages),
-                previous_extractions=[],
+                parsed=parsed,
+                grobid_error=exc,
+                reason="grobid_error",
             )
-            return fallback_result
 
         structured = converted.get("structured") if isinstance(converted.get("structured"), dict) else {}
         text = str(converted.get("text") or "").strip()
         if not text:
-            return None
+            if not parsed.fallback_to_pypdf:
+                return None
+            return self._fallback_extract(
+                corpus=corpus,
+                item=item,
+                parsed=parsed,
+                grobid_error=UrlTextExtractionError(
+                    code="grobid_empty_text",
+                    message="GROBID returned no extractable body text.",
+                ),
+                reason="grobid_empty_text",
+            )
         return ExtractedText(
             text=text,
             producer_extractor_id=self.extractor_id,
@@ -111,4 +137,47 @@ class GrobidPortableDocumentFormatTextExtractor(TextExtractor):
                 "structured": structured,
                 "title": converted.get("title"),
             },
+        )
+
+    def _fallback_extract(
+        self,
+        *,
+        corpus,
+        item: CatalogItem,
+        parsed: GrobidPortableDocumentFormatTextExtractorConfig,
+        grobid_error: UrlTextExtractionError,
+        reason: str,
+    ) -> Optional[ExtractedText]:
+        fallback = PortableDocumentFormatTextExtractor()
+        fallback_result = fallback.extract_text(
+            corpus=corpus,
+            item=item,
+            config=PortableDocumentFormatTextExtractorConfig(max_pages=parsed.max_pages),
+            previous_extractions=[],
+        )
+        if fallback_result is None:
+            return None
+        metadata: Dict[str, Any] = {}
+        if parsed.record_fallback_metadata:
+            metadata = {
+                "method": "pypdf-fallback",
+                "grobid_fallback": {
+                    "reason": reason,
+                    "code": grobid_error.code,
+                    "message": grobid_error.message,
+                    "details": grobid_error.details if isinstance(grobid_error.details, dict) else {},
+                },
+                "structured": _empty_structured_payload(
+                    warnings=[
+                        {
+                            "code": reason,
+                            "message": grobid_error.message,
+                        }
+                    ]
+                ),
+            }
+        return ExtractedText(
+            text=fallback_result.text,
+            producer_extractor_id=self.extractor_id,
+            metadata=metadata,
         )

--- a/src/biblicus/extractors/grobid_pdf_text.py
+++ b/src/biblicus/extractors/grobid_pdf_text.py
@@ -1,0 +1,114 @@
+"""
+Portable Document Format text extractor backed by GROBID.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..models import CatalogItem, ExtractedText, ExtractionStageOutput
+from ..url_text import UrlTextExtractionError, _convert_pdf_with_grobid
+from .base import TextExtractor
+from .pdf_text import PortableDocumentFormatTextExtractor, PortableDocumentFormatTextExtractorConfig
+
+
+class GrobidPortableDocumentFormatTextExtractorConfig(BaseModel):
+    """
+    Configuration for GROBID-backed PDF text extraction.
+
+    :ivar max_pages: Optional maximum number of pages (reserved for future use).
+    :vartype max_pages: int or None
+    :ivar fallback_to_pypdf: Use pypdf when GROBID is unavailable.
+    :vartype fallback_to_pypdf: bool
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_pages: Optional[int] = Field(default=None, ge=1)
+    fallback_to_pypdf: bool = Field(default=True)
+
+
+class GrobidPortableDocumentFormatTextExtractor(TextExtractor):
+    """
+    Extract PDF text and structured metadata using GROBID when configured.
+    """
+
+    extractor_id = "grobid-pdf-text"
+
+    def validate_config(self, config: Dict[str, Any]) -> BaseModel:
+        """
+        Validate extractor configuration.
+
+        :param config: Configuration mapping.
+        :type config: dict[str, Any]
+        :return: Parsed configuration.
+        :rtype: GrobidPortableDocumentFormatTextExtractorConfig
+        """
+        return GrobidPortableDocumentFormatTextExtractorConfig.model_validate(config)
+
+    def extract_text(
+        self,
+        *,
+        corpus,
+        item: CatalogItem,
+        config: BaseModel,
+        previous_extractions: List[ExtractionStageOutput],
+    ) -> Optional[ExtractedText]:
+        """
+        Extract text for a PDF using GROBID, with optional pypdf fallback.
+
+        :param corpus: Corpus containing the item bytes.
+        :type corpus: Corpus
+        :param item: Catalog item being processed.
+        :type item: CatalogItem
+        :param config: Parsed configuration model.
+        :type config: BaseModel
+        :param previous_extractions: Prior stage outputs (ignored).
+        :type previous_extractions: list[ExtractionStageOutput]
+        :return: Extracted text payload, or None when the item is not a PDF.
+        :rtype: ExtractedText or None
+        """
+        _ = previous_extractions
+        if item.media_type != "application/pdf":
+            return None
+        parsed = (
+            config
+            if isinstance(config, GrobidPortableDocumentFormatTextExtractorConfig)
+            else GrobidPortableDocumentFormatTextExtractorConfig.model_validate(config)
+        )
+        pdf_path = corpus.root / item.relpath
+        pdf_bytes = pdf_path.read_bytes()
+        try:
+            converted = _convert_pdf_with_grobid(
+                data=pdf_bytes,
+                source_uri=str(pdf_path),
+                content_type=item.media_type,
+            )
+        except UrlTextExtractionError:
+            if not parsed.fallback_to_pypdf:
+                raise
+            fallback = PortableDocumentFormatTextExtractor()
+            fallback_result = fallback.extract_text(
+                corpus=corpus,
+                item=item,
+                config=PortableDocumentFormatTextExtractorConfig(max_pages=parsed.max_pages),
+                previous_extractions=[],
+            )
+            return fallback_result
+
+        structured = converted.get("structured") if isinstance(converted.get("structured"), dict) else {}
+        text = str(converted.get("text") or "").strip()
+        if not text:
+            return None
+        return ExtractedText(
+            text=text,
+            producer_extractor_id=self.extractor_id,
+            metadata={
+                "method": "grobid",
+                "grobid": converted.get("grobid") if isinstance(converted.get("grobid"), dict) else {},
+                "structured": structured,
+                "title": converted.get("title"),
+            },
+        )

--- a/src/biblicus/extractors/html_web_metadata.py
+++ b/src/biblicus/extractors/html_web_metadata.py
@@ -1,0 +1,169 @@
+"""
+Attach BeautifulSoup web metadata to HTML corpus items during text extraction.
+
+Runs after markitdown (or similar) so final pipeline text is unchanged while
+``metadata/{item_id}.json`` carries ``method`` and ``structured`` for graph NER dedup.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..corpus import Corpus
+from ..models import CatalogItem, ExtractedText, ExtractionStageOutput
+from ..web_reference_metadata import (
+    LOCAL_HTML_SOURCE_URI,
+    extraction_metadata_from_web_payload,
+    extract_web_reference_metadata_from_html,
+)
+from .base import TextExtractor
+
+_DEFAULT_HTML_MEDIA_PATTERNS = (
+    "text/html",
+    "application/xhtml+xml",
+    "application/xhtml*",
+)
+
+
+class HtmlWebMetadataExtractorConfig(BaseModel):
+    """
+    Configuration for HTML web metadata attachment.
+
+    :ivar media_type_patterns: Media types that receive heuristic metadata extraction.
+    :vartype media_type_patterns: list[str]
+    :ivar use_llm_fallback: Whether to run LLM structured enrichment when heuristics are sparse.
+    :vartype use_llm_fallback: bool
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    media_type_patterns: List[str] = Field(default_factory=lambda: list(_DEFAULT_HTML_MEDIA_PATTERNS))
+    use_llm_fallback: bool = Field(default=False)
+
+
+class HtmlWebMetadataExtractor(TextExtractor):
+    """
+    Pipeline stage that enriches HTML items with shared web heuristic metadata.
+    """
+
+    extractor_id = "html-web-metadata"
+
+    def validate_config(self, config: Dict[str, Any]) -> BaseModel:
+        """
+        Validate extractor configuration.
+
+        :param config: Configuration mapping.
+        :type config: dict[str, Any]
+        :return: Parsed configuration.
+        :rtype: HtmlWebMetadataExtractorConfig
+        """
+        return HtmlWebMetadataExtractorConfig.model_validate(config)
+
+    def extract_text(
+        self,
+        *,
+        corpus: Corpus,
+        item: CatalogItem,
+        config: BaseModel,
+        previous_extractions: List[ExtractionStageOutput],
+    ) -> Optional[ExtractedText]:
+        """
+        Pass through prior stage text and attach web heuristic metadata for HTML items.
+
+        :param corpus: Corpus containing the item bytes.
+        :type corpus: Corpus
+        :param item: Catalog item being processed.
+        :type item: CatalogItem
+        :param config: Parsed configuration model.
+        :type config: HtmlWebMetadataExtractorConfig
+        :param previous_extractions: Prior stage outputs for this item within the pipeline.
+        :type previous_extractions: list[ExtractionStageOutput]
+        :return: Text plus metadata when HTML matches; otherwise None.
+        :rtype: ExtractedText or None
+        """
+        parsed = (
+            config
+            if isinstance(config, HtmlWebMetadataExtractorConfig)
+            else HtmlWebMetadataExtractorConfig.model_validate(config)
+        )
+        if not _matches_html_media_type(item.media_type, parsed.media_type_patterns):
+            return None
+
+        prior_text = _latest_prior_text(previous_extractions)
+        if prior_text is None:
+            return None
+
+        source_path = corpus.root / item.relpath
+        try:
+            html_body = source_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ExtractedText(
+                text=prior_text,
+                producer_extractor_id=self.extractor_id,
+                metadata={
+                    "method": "html_heuristics_unavailable",
+                    "structured": {
+                        "authors": [],
+                        "citations": [],
+                        "warnings": [
+                            {
+                                "code": "html_read_failed",
+                                "message": f"Could not read HTML file at {item.relpath}.",
+                            }
+                        ],
+                    },
+                },
+            )
+
+        source_uri = _resolve_source_uri(item, source_path)
+        payload = extract_web_reference_metadata_from_html(
+            html_body,
+            source_uri=source_uri,
+            reference_title=str(item.title or ""),
+            use_llm_fallback=parsed.use_llm_fallback,
+        )
+        metadata = extraction_metadata_from_web_payload(payload)
+        producer = _latest_prior_producer(previous_extractions) or self.extractor_id
+        return ExtractedText(
+            text=prior_text,
+            producer_extractor_id=producer,
+            metadata=metadata,
+        )
+
+
+def _matches_html_media_type(media_type: str, patterns: List[str]) -> bool:
+    normalized = str(media_type or "").strip().lower()
+    if not normalized:
+        return False
+    return any(fnmatch.fnmatch(normalized, pattern.lower()) for pattern in patterns)
+
+
+def _latest_prior_text(previous_extractions: List[ExtractionStageOutput]) -> Optional[str]:
+    for stage in reversed(previous_extractions):
+        text = str(stage.text or "").strip()
+        if text:
+            return stage.text or ""
+    return None
+
+
+def _latest_prior_producer(previous_extractions: List[ExtractionStageOutput]) -> Optional[str]:
+    for stage in reversed(previous_extractions):
+        if str(stage.text or "").strip():
+            return stage.producer_extractor_id or stage.extractor_id
+    return None
+
+
+def _resolve_source_uri(item: CatalogItem, source_path: Path) -> str:
+    explicit = str(item.source_uri or "").strip()
+    if explicit:
+        return explicit
+    metadata = item.metadata if isinstance(item.metadata, dict) else {}
+    for key in ("source_uri", "sourceUri", "url", "canonical_uri", "canonicalUri"):
+        value = str(metadata.get(key) or "").strip()
+        if value:
+            return value
+    return f"{LOCAL_HTML_SOURCE_URI.rstrip('/')}/{source_path.name}"

--- a/src/biblicus/extractors/markitdown_text.py
+++ b/src/biblicus/extractors/markitdown_text.py
@@ -16,6 +16,16 @@ from ..errors import ExtractionSnapshotFatalError
 from ..models import CatalogItem, ExtractedText, ExtractionStageOutput
 from .base import TextExtractor
 
+# Media types handled by pass-through-text; markitdown converts HTML and binary formats.
+_MARKITDOWN_SKIP_MEDIA_TYPES = frozenset(
+    {
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/tab-separated-values",
+    }
+)
+
 
 class MarkItDownExtractorConfig(BaseModel):
     """
@@ -97,8 +107,13 @@ class MarkItDownExtractor(TextExtractor):
             else MarkItDownExtractorConfig.model_validate(config)
         )
         _ = previous_extractions
-        media_type = item.media_type
-        if media_type == "text/markdown" or media_type.startswith("text/"):
+        media_type = str(item.media_type or "").strip().lower()
+        if media_type in _MARKITDOWN_SKIP_MEDIA_TYPES:
+            return None
+        if media_type.startswith("text/") and media_type not in {
+            "text/html",
+            "application/xhtml+xml",
+        }:
             return None
 
         from markitdown import MarkItDown

--- a/src/biblicus/extractors/pdf_text.py
+++ b/src/biblicus/extractors/pdf_text.py
@@ -85,7 +85,20 @@ class PortableDocumentFormatTextExtractor(TextExtractor):
 
         pdf_path = corpus.root / item.relpath
         pdf_bytes = pdf_path.read_bytes()
-        reader = PdfReader(BytesIO(pdf_bytes))
+        try:
+            reader = PdfReader(BytesIO(pdf_bytes), strict=False)
+        except Exception as exc:
+            return ExtractedText(
+                text="",
+                producer_extractor_id=self.extractor_id,
+                metadata={
+                    "pdf_error": {
+                        "code": "pdf_reader_failed",
+                        "message": str(exc),
+                        "relpath": item.relpath,
+                    }
+                },
+            )
 
         texts: list[str] = []
         pages = list(reader.pages)
@@ -93,7 +106,10 @@ class PortableDocumentFormatTextExtractor(TextExtractor):
             pages = pages[: int(parsed_config.max_pages)]
 
         for page in pages:
-            page_text = page.extract_text() or ""
+            try:
+                page_text = page.extract_text() or ""
+            except Exception:
+                continue
             texts.append(page_text)
 
         combined_text = "\n".join(texts).strip()

--- a/src/biblicus/extractors/select_override.py
+++ b/src/biblicus/extractors/select_override.py
@@ -116,6 +116,7 @@ class SelectOverrideExtractor(TextExtractor):
         return ExtractedText(
             text=candidate.text or "",
             producer_extractor_id=producer,
-            source_stage_index=candidate.stage_index,
+            source_stage_index=candidate.source_stage_index or candidate.stage_index,
             confidence=candidate.confidence,
+            metadata=dict(candidate.metadata or {}),
         )

--- a/src/biblicus/graph/base.py
+++ b/src/biblicus/graph/base.py
@@ -5,7 +5,7 @@ Graph extractor interface for Biblicus.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -44,6 +44,7 @@ class GraphExtractor(ABC):
         item: CatalogItem,
         extracted_text: str,
         config: BaseModel,
+        extraction_metadata: Optional[Dict[str, Any]] = None,
     ) -> GraphExtractionResult:
         """
         Extract graph nodes and edges for a single item.
@@ -56,6 +57,8 @@ class GraphExtractor(ABC):
         :type extracted_text: str
         :param config: Parsed extractor configuration.
         :type config: pydantic.BaseModel
+        :param extraction_metadata: Optional per-item extraction metadata (e.g. GROBID structured).
+        :type extraction_metadata: dict[str, Any] or None
         :return: Graph extraction result.
         :rtype: GraphExtractionResult
         """

--- a/src/biblicus/graph/extraction.py
+++ b/src/biblicus/graph/extraction.py
@@ -5,8 +5,12 @@ Graph extraction snapshots for Biblicus.
 from __future__ import annotations
 
 import json
+import signal
+import threading
+import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -17,14 +21,23 @@ from ..time import utc_now_iso
 from .extractors import get_graph_extractor
 from .models import (
     GraphConfigurationManifest,
+    GraphExportEdge,
+    GraphExportNode,
     GraphExtractionItemSummary,
     GraphExtractionResult,
+    GraphSnapshotExport,
     GraphSnapshotListEntry,
     GraphSnapshotManifest,
     GraphSnapshotReference,
     parse_graph_snapshot_reference,
 )
-from .neo4j import create_neo4j_driver, resolve_neo4j_settings, write_graph_records
+from .neo4j import (
+    clear_graph_records,
+    create_neo4j_driver,
+    read_graph_records,
+    resolve_neo4j_settings,
+    write_graph_records,
+)
 
 
 def create_graph_configuration_manifest(
@@ -153,6 +166,11 @@ def build_graph_snapshot(
     configuration_name: str,
     configuration: Dict[str, Any],
     extraction_snapshot: ExtractionSnapshotReference,
+    max_items: Optional[int] = None,
+    item_timeout_seconds: Optional[float] = 60.0,
+    item_retry_attempts: int = 0,
+    heartbeat_interval_seconds: float = 10.0,
+    progress_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
 ) -> GraphSnapshotManifest:
     """
     Build a graph extraction snapshot for a corpus.
@@ -167,6 +185,17 @@ def build_graph_snapshot(
     :type configuration: dict[str, Any]
     :param extraction_snapshot: Extraction snapshot reference.
     :type extraction_snapshot: ExtractionSnapshotReference
+    :param max_items: Optional maximum number of extraction items to process.
+    :type max_items: int or None
+    :param item_timeout_seconds: Optional per-item extraction timeout in seconds.
+        Non-positive values disable timeout enforcement.
+    :type item_timeout_seconds: float or None
+    :param item_retry_attempts: Number of retries after a failed extraction attempt.
+    :type item_retry_attempts: int
+    :param heartbeat_interval_seconds: Progress heartbeat cadence in seconds.
+    :type heartbeat_interval_seconds: float
+    :param progress_callback: Optional callback for progress events.
+    :type progress_callback: collections.abc.Callable or None
     :return: Graph snapshot manifest.
     :rtype: GraphSnapshotManifest
     """
@@ -176,11 +205,14 @@ def build_graph_snapshot(
     except ValidationError as exc:
         raise ValueError(f"Invalid graph extraction configuration: {exc}") from exc
 
-    graph_id = create_graph_id(extractor_id=extractor_id, configuration=configuration)
+    snapshot_configuration = dict(configuration)
+    if max_items is not None:
+        snapshot_configuration["_execution"] = {"max_items": max_items}
+    graph_id = create_graph_id(extractor_id=extractor_id, configuration=snapshot_configuration)
     configuration_manifest = create_graph_configuration_manifest(
         extractor_id=extractor_id,
         name=configuration_name,
-        configuration=configuration,
+        configuration=snapshot_configuration,
     )
     manifest = create_graph_snapshot_manifest(
         corpus,
@@ -192,6 +224,16 @@ def build_graph_snapshot(
         extractor_id=extraction_snapshot.extractor_id,
         snapshot_id=extraction_snapshot.snapshot_id,
     )
+    extraction_items = list(extraction_manifest.items)
+    if max_items is not None:
+        if max_items <= 0:
+            raise ValueError("max_items must be a positive integer")
+        extraction_items = extraction_items[:max_items]
+    timeout_seconds = float(item_timeout_seconds) if item_timeout_seconds is not None else None
+    if timeout_seconds is not None and timeout_seconds <= 0:
+        timeout_seconds = None
+    retry_attempts = max(0, int(item_retry_attempts))
+    heartbeat_seconds = max(0.0, float(heartbeat_interval_seconds))
 
     snapshot_dir = corpus.graph_snapshot_dir(
         extractor_id=extractor_id,
@@ -200,71 +242,407 @@ def build_graph_snapshot(
     snapshot_dir.mkdir(parents=True, exist_ok=True)
 
     settings = resolve_neo4j_settings()
+    _emit_graph_progress(
+        progress_callback,
+        "starting",
+        snapshot_id=manifest.snapshot_id,
+        extractor_id=extractor_id,
+        items_total=len(extraction_items),
+        items_available=len(extraction_manifest.items),
+    )
     driver = create_neo4j_driver(settings)
 
     node_total = 0
     edge_total = 0
+    errored_total = 0
+    timed_out_total = 0
+    skipped_total = 0
     item_summaries: List[GraphExtractionItemSummary] = []
+    started_monotonic = time.monotonic()
+    last_heartbeat_monotonic = started_monotonic
 
     try:
-        for item_result in extraction_manifest.items:
-            item = corpus.get_item(item_result.item_id)
-            extracted_text = _load_extracted_text(
-                corpus,
-                extraction_snapshot=extraction_snapshot,
-                item_result=item_result,
+        clear_graph_records(
+            driver=driver,
+            settings=settings,
+            corpus_id=corpus.uri,
+            graph_id=graph_id,
+            extraction_snapshot=extraction_snapshot.as_string(),
+        )
+        for index, item_result in enumerate(extraction_items, start=1):
+            last_heartbeat_monotonic = _maybe_emit_graph_heartbeat(
+                progress_callback=progress_callback,
+                snapshot_id=manifest.snapshot_id,
+                extractor_id=extractor_id,
+                items_total=len(extraction_items),
+                items_available=len(extraction_manifest.items),
+                item_index=index - 1,
+                node_total=node_total,
+                edge_total=edge_total,
+                skipped_total=skipped_total,
+                errored_total=errored_total,
+                timed_out_total=timed_out_total,
+                started_monotonic=started_monotonic,
+                heartbeat_interval_seconds=heartbeat_seconds,
+                last_heartbeat_monotonic=last_heartbeat_monotonic,
             )
-            if extracted_text is None:
+            item = corpus.get_item(item_result.item_id)
+            item_started_monotonic = time.monotonic()
+            _emit_graph_progress(
+                progress_callback,
+                "processing",
+                snapshot_id=manifest.snapshot_id,
+                item_id=item.id,
+                item_index=index,
+                items_total=len(extraction_items),
+                elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+            )
+            try:
+                extracted_text = _load_extracted_text(
+                    corpus,
+                    extraction_snapshot=extraction_snapshot,
+                    item_result=item_result,
+                )
+                extraction_metadata = _load_extracted_metadata(
+                    corpus,
+                    extraction_snapshot=extraction_snapshot,
+                    item_result=item_result,
+                )
+                if extracted_text is None:
+                    skipped_total += 1
+                    item_summaries.append(
+                        GraphExtractionItemSummary(
+                            item_id=item.id,
+                            status="skipped",
+                            node_count=0,
+                            edge_count=0,
+                            error_message="No extracted text",
+                            error_reason="no_extracted_text",
+                            duration_ms=int((time.monotonic() - item_started_monotonic) * 1000),
+                            attempts=1,
+                        )
+                    )
+                    _emit_graph_progress(
+                        progress_callback,
+                        "processed",
+                        snapshot_id=manifest.snapshot_id,
+                        item_id=item.id,
+                        item_index=index,
+                        items_total=len(extraction_items),
+                        status="skipped",
+                        nodes=node_total,
+                        edges=edge_total,
+                        attempts=1,
+                        duration_ms=int((time.monotonic() - item_started_monotonic) * 1000),
+                        error_reason="no_extracted_text",
+                        elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+                    )
+                    continue
+                result, attempts = _run_extractor_with_retry(
+                    extractor=extractor,
+                    corpus=corpus,
+                    item=item,
+                    extracted_text=extracted_text,
+                    extraction_metadata=extraction_metadata,
+                    config=parsed_config,
+                    timeout_seconds=timeout_seconds,
+                    retry_attempts=retry_attempts,
+                )
+                if not isinstance(result, GraphExtractionResult):
+                    raise ValueError("Graph extractor must return GraphExtractionResult")
+                write_graph_records(
+                    driver=driver,
+                    settings=settings,
+                    corpus_id=corpus.uri,
+                    graph_id=graph_id,
+                    extraction_snapshot=extraction_snapshot.as_string(),
+                    item_id=item.id,
+                    nodes=result.nodes,
+                    edges=result.edges,
+                )
+                node_total += len(result.nodes)
+                edge_total += len(result.edges)
                 item_summaries.append(
                     GraphExtractionItemSummary(
                         item_id=item.id,
-                        status="skipped",
-                        node_count=0,
-                        edge_count=0,
-                        error_message="No extracted text",
+                        status="complete",
+                        node_count=len(result.nodes),
+                        edge_count=len(result.edges),
+                        duration_ms=int((time.monotonic() - item_started_monotonic) * 1000),
+                        attempts=attempts,
                     )
                 )
-                continue
-            result = extractor.extract_graph(
-                corpus=corpus,
-                item=item,
-                extracted_text=extracted_text,
-                config=parsed_config,
-            )
-            if not isinstance(result, GraphExtractionResult):
-                raise ValueError("Graph extractor must return GraphExtractionResult")
-            write_graph_records(
-                driver=driver,
-                settings=settings,
-                corpus_id=corpus.uri,
-                graph_id=graph_id,
-                extraction_snapshot=extraction_snapshot.as_string(),
-                item_id=item.id,
-                nodes=result.nodes,
-                edges=result.edges,
-            )
-            node_total += len(result.nodes)
-            edge_total += len(result.edges)
-            item_summaries.append(
-                GraphExtractionItemSummary(
+                _emit_graph_progress(
+                    progress_callback,
+                    "processed",
+                    snapshot_id=manifest.snapshot_id,
                     item_id=item.id,
+                    item_index=index,
+                    items_total=len(extraction_items),
                     status="complete",
-                    node_count=len(result.nodes),
-                    edge_count=len(result.edges),
+                    nodes=node_total,
+                    edges=edge_total,
+                    attempts=attempts,
+                    duration_ms=int((time.monotonic() - item_started_monotonic) * 1000),
+                    elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
                 )
-            )
+            except _ExtractorExecutionError as exc:
+                errored_total += 1
+                if exc.reason == "timeout":
+                    timed_out_total += 1
+                duration_ms = int((time.monotonic() - item_started_monotonic) * 1000)
+                item_summaries.append(
+                    GraphExtractionItemSummary(
+                        item_id=item.id,
+                        status="error",
+                        node_count=0,
+                        edge_count=0,
+                        error_message=str(exc),
+                        error_reason=exc.reason,
+                        duration_ms=duration_ms,
+                        attempts=exc.attempts,
+                    )
+                )
+                _emit_graph_progress(
+                    progress_callback,
+                    "processed",
+                    snapshot_id=manifest.snapshot_id,
+                    item_id=item.id,
+                    item_index=index,
+                    items_total=len(extraction_items),
+                    status="error",
+                    error_message=str(exc),
+                    error_reason=exc.reason,
+                    attempts=exc.attempts,
+                    duration_ms=duration_ms,
+                    nodes=node_total,
+                    edges=edge_total,
+                    elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+                )
+            except ValueError as exc:
+                if "Graph extractor must return GraphExtractionResult" in str(exc):
+                    raise
+                errored_total += 1
+                duration_ms = int((time.monotonic() - item_started_monotonic) * 1000)
+                item_summaries.append(
+                    GraphExtractionItemSummary(
+                        item_id=item.id,
+                        status="error",
+                        node_count=0,
+                        edge_count=0,
+                        error_message=str(exc),
+                        error_reason="value_error",
+                        duration_ms=duration_ms,
+                        attempts=1,
+                    )
+                )
+                _emit_graph_progress(
+                    progress_callback,
+                    "processed",
+                    snapshot_id=manifest.snapshot_id,
+                    item_id=item.id,
+                    item_index=index,
+                    items_total=len(extraction_items),
+                    status="error",
+                    error_message=str(exc),
+                    error_reason="value_error",
+                    attempts=1,
+                    duration_ms=duration_ms,
+                    nodes=node_total,
+                    edges=edge_total,
+                    elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+                )
+            except Exception as exc:
+                errored_total += 1
+                duration_ms = int((time.monotonic() - item_started_monotonic) * 1000)
+                item_summaries.append(
+                    GraphExtractionItemSummary(
+                        item_id=item.id,
+                        status="error",
+                        node_count=0,
+                        edge_count=0,
+                        error_message=str(exc),
+                        error_reason="exception",
+                        duration_ms=duration_ms,
+                        attempts=1,
+                    )
+                )
+                _emit_graph_progress(
+                    progress_callback,
+                    "processed",
+                    snapshot_id=manifest.snapshot_id,
+                    item_id=item.id,
+                    item_index=index,
+                    items_total=len(extraction_items),
+                    status="error",
+                    error_message=str(exc),
+                    error_reason="exception",
+                    attempts=1,
+                    duration_ms=duration_ms,
+                    nodes=node_total,
+                    edges=edge_total,
+                    elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+                )
     finally:
         driver.close()
 
     manifest.stats = {
-        "items_total": len(extraction_manifest.items),
+        "items_total": len(extraction_items),
+        "items_available": len(extraction_manifest.items),
         "items_processed": len(item_summaries),
+        "items_skipped": skipped_total,
+        "items_errored": errored_total,
+        "items_timed_out": timed_out_total,
         "nodes": node_total,
         "edges": edge_total,
+        "item_timeout_seconds": timeout_seconds,
+        "item_retry_attempts": retry_attempts,
+        "item_summaries": [summary.model_dump(mode="json") for summary in item_summaries],
     }
+    _emit_graph_progress(
+        progress_callback,
+        "completed",
+        snapshot_id=manifest.snapshot_id,
+        extractor_id=extractor_id,
+        items_total=len(extraction_items),
+        items_available=len(extraction_manifest.items),
+        items_processed=len(item_summaries),
+        items_skipped=skipped_total,
+        items_errored=errored_total,
+        items_timed_out=timed_out_total,
+        nodes=node_total,
+        edges=edge_total,
+        elapsed_ms=int((time.monotonic() - started_monotonic) * 1000),
+    )
     write_graph_snapshot_manifest(snapshot_dir=snapshot_dir, manifest=manifest)
     write_graph_latest_pointer(extractor_dir=snapshot_dir.parent, manifest=manifest)
     return manifest
+
+
+def _emit_graph_progress(
+    progress_callback: Optional[Callable[[str, Dict[str, Any]], None]],
+    event: str,
+    **payload: Any,
+) -> None:
+    if progress_callback is None:
+        return
+    progress_callback(event, payload)
+
+
+class _ExtractorExecutionError(RuntimeError):
+    def __init__(self, *, reason: str, message: str, attempts: int) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.attempts = attempts
+
+
+class _ItemExtractionTimeout(RuntimeError):
+    pass
+
+
+def _run_extractor_with_retry(
+    *,
+    extractor,
+    corpus: Corpus,
+    item,
+    extracted_text: str,
+    extraction_metadata: dict[str, Any] | None,
+    config,
+    timeout_seconds: float | None,
+    retry_attempts: int,
+) -> tuple[Any, int]:
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            with _item_timeout_guard(timeout_seconds):
+                result = extractor.extract_graph(
+                    corpus=corpus,
+                    item=item,
+                    extracted_text=extracted_text,
+                    config=config,
+                    extraction_metadata=extraction_metadata,
+                )
+            return result, attempts
+        except _ItemExtractionTimeout as exc:
+            if attempts <= retry_attempts:
+                continue
+            timeout_label = timeout_seconds if timeout_seconds is not None else "-"
+            raise _ExtractorExecutionError(
+                reason="timeout",
+                message=f"item extraction timed out after {timeout_label}s (attempts={attempts})",
+                attempts=attempts,
+            ) from exc
+        except Exception as exc:
+            if attempts <= retry_attempts:
+                continue
+            reason = "value_error" if isinstance(exc, ValueError) else "exception"
+            raise _ExtractorExecutionError(reason=reason, message=str(exc), attempts=attempts) from exc
+
+
+@contextmanager
+def _item_timeout_guard(timeout_seconds: float | None):
+    if timeout_seconds is None or timeout_seconds <= 0:
+        yield
+        return
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+    if not hasattr(signal, "setitimer"):
+        yield
+        return
+
+    def _raise_timeout(_signum, _frame):
+        raise _ItemExtractionTimeout(f"item extraction exceeded {timeout_seconds}s")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, _raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout_seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def _maybe_emit_graph_heartbeat(
+    *,
+    progress_callback: Optional[Callable[[str, Dict[str, Any]], None]],
+    snapshot_id: str,
+    extractor_id: str,
+    items_total: int,
+    items_available: int,
+    item_index: int,
+    node_total: int,
+    edge_total: int,
+    skipped_total: int,
+    errored_total: int,
+    timed_out_total: int,
+    started_monotonic: float,
+    heartbeat_interval_seconds: float,
+    last_heartbeat_monotonic: float,
+) -> float:
+    if progress_callback is None or heartbeat_interval_seconds <= 0:
+        return last_heartbeat_monotonic
+    now = time.monotonic()
+    if (now - last_heartbeat_monotonic) < heartbeat_interval_seconds:
+        return last_heartbeat_monotonic
+    _emit_graph_progress(
+        progress_callback,
+        "heartbeat",
+        snapshot_id=snapshot_id,
+        extractor_id=extractor_id,
+        items_total=items_total,
+        items_available=items_available,
+        item_index=item_index,
+        nodes=node_total,
+        edges=edge_total,
+        items_skipped=skipped_total,
+        items_errored=errored_total,
+        items_timed_out=timed_out_total,
+        elapsed_ms=int((now - started_monotonic) * 1000),
+    )
+    return now
 
 
 def _load_extracted_text(
@@ -283,6 +661,25 @@ def _load_extracted_text(
     if not text_path.is_file():
         return None
     return text_path.read_text(encoding="utf-8")
+
+
+def _load_extracted_metadata(
+    corpus: Corpus,
+    *,
+    extraction_snapshot: ExtractionSnapshotReference,
+    item_result,
+) -> Optional[dict[str, Any]]:
+    if not item_result.final_metadata_relpath:
+        return None
+    snapshot_dir = corpus.extraction_snapshot_dir(
+        extractor_id=extraction_snapshot.extractor_id,
+        snapshot_id=extraction_snapshot.snapshot_id,
+    )
+    metadata_path = snapshot_dir / item_result.final_metadata_relpath
+    if not metadata_path.is_file():
+        return None
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else None
 
 
 def load_graph_snapshot_manifest(
@@ -310,6 +707,86 @@ def load_graph_snapshot_manifest(
         raise FileNotFoundError(f"Missing graph snapshot manifest: {manifest_path}")
     data = json.loads(manifest_path.read_text(encoding="utf-8"))
     return GraphSnapshotManifest.model_validate(data)
+
+
+def export_graph_snapshot(
+    corpus: Corpus, *, snapshot: GraphSnapshotReference
+) -> GraphSnapshotExport:
+    """
+    Export graph snapshot contents from Neo4j as portable JSON records.
+
+    :param corpus: Corpus containing the snapshot manifest.
+    :type corpus: Corpus
+    :param snapshot: Graph snapshot reference.
+    :type snapshot: GraphSnapshotReference
+    :return: Portable graph snapshot export.
+    :rtype: GraphSnapshotExport
+    """
+    manifest = load_graph_snapshot_manifest(
+        corpus,
+        extractor_id=snapshot.extractor_id,
+        snapshot_id=snapshot.snapshot_id,
+    )
+    settings = resolve_neo4j_settings()
+    driver = create_neo4j_driver(settings)
+    try:
+        records = read_graph_records(
+            driver=driver,
+            settings=settings,
+            corpus_id=corpus.uri,
+            graph_id=manifest.graph_id,
+            extraction_snapshot=manifest.extraction_snapshot,
+        )
+    finally:
+        driver.close()
+
+    nodes = [
+        GraphExportNode(
+            extractor_id=snapshot.extractor_id,
+            snapshot_id=snapshot.snapshot_id,
+            graph_id=manifest.graph_id,
+            extraction_snapshot=manifest.extraction_snapshot,
+            item_id=str(entry["item_id"]),
+            node_id=str(entry["node_id"]),
+            node_type=str(entry["node_type"]),
+            label=str(entry["label"]),
+            properties=dict(entry.get("properties") or {}),
+        )
+        for entry in sorted(
+            records["nodes"],
+            key=lambda item: (str(item.get("item_id", "")), str(item.get("node_id", ""))),
+        )
+    ]
+    edges = [
+        GraphExportEdge(
+            extractor_id=snapshot.extractor_id,
+            snapshot_id=snapshot.snapshot_id,
+            graph_id=manifest.graph_id,
+            extraction_snapshot=manifest.extraction_snapshot,
+            item_id=str(entry["item_id"]),
+            edge_id=str(entry["edge_id"]),
+            src=str(entry["src"]),
+            dst=str(entry["dst"]),
+            edge_type=str(entry["edge_type"]),
+            weight=float(entry.get("weight", 1.0)),
+            properties=dict(entry.get("properties") or {}),
+        )
+        for entry in sorted(
+            records["edges"],
+            key=lambda item: (str(item.get("item_id", "")), str(item.get("edge_id", ""))),
+        )
+    ]
+    return GraphSnapshotExport(
+        snapshot=snapshot,
+        manifest=manifest,
+        nodes=nodes,
+        edges=edges,
+        stats={
+            **manifest.stats,
+            "exported_nodes": len(nodes),
+            "exported_edges": len(edges),
+        },
+    )
 
 
 def list_graph_snapshots(
@@ -392,9 +869,7 @@ def latest_graph_snapshot_reference(
     return GraphSnapshotReference(extractor_id=latest.extractor_id, snapshot_id=latest.snapshot_id)
 
 
-def resolve_graph_snapshot_reference(
-    corpus: Corpus, *, raw: str
-) -> GraphSnapshotReference:
+def resolve_graph_snapshot_reference(corpus: Corpus, *, raw: str) -> GraphSnapshotReference:
     """
     Resolve a graph snapshot reference from a raw string.
 

--- a/src/biblicus/graph/extraction.py
+++ b/src/biblicus/graph/extraction.py
@@ -199,20 +199,37 @@ def build_graph_snapshot(
     :return: Graph snapshot manifest.
     :rtype: GraphSnapshotManifest
     """
+    snapshot_configuration = dict(configuration)
+    execution_block = snapshot_configuration.pop("_execution", None)
+    if not isinstance(execution_block, dict):
+        execution_block = {}
+    graph_execution = snapshot_configuration.pop("graph", None)
+    if isinstance(graph_execution, dict):
+        if "max_items" in graph_execution and max_items is None:
+            max_items = int(graph_execution["max_items"])
+        execution_block = {**graph_execution, **execution_block}
+    if max_items is not None:
+        execution_block["max_items"] = max_items
+
     extractor = get_graph_extractor(extractor_id)
     try:
-        parsed_config = extractor.validate_config(configuration)
+        parsed_config = extractor.validate_config(snapshot_configuration)
     except ValidationError as exc:
         raise ValueError(f"Invalid graph extraction configuration: {exc}") from exc
 
-    snapshot_configuration = dict(configuration)
-    if max_items is not None:
-        snapshot_configuration["_execution"] = {"max_items": max_items}
-    graph_id = create_graph_id(extractor_id=extractor_id, configuration=snapshot_configuration)
+    if max_items is None:
+        execution_max_items = execution_block.get("max_items") if execution_block else None
+        if execution_max_items is not None:
+            max_items = int(execution_max_items)
+
+    manifest_configuration = dict(snapshot_configuration)
+    if execution_block:
+        manifest_configuration["_execution"] = execution_block
+    graph_id = create_graph_id(extractor_id=extractor_id, configuration=manifest_configuration)
     configuration_manifest = create_graph_configuration_manifest(
         extractor_id=extractor_id,
         name=configuration_name,
-        configuration=snapshot_configuration,
+        configuration=manifest_configuration,
     )
     manifest = create_graph_snapshot_manifest(
         corpus,

--- a/src/biblicus/graph/extractors/cooccurrence.py
+++ b/src/biblicus/graph/extractors/cooccurrence.py
@@ -58,6 +58,7 @@ class CooccurrenceGraphExtractor(GraphExtractor):
         item: CatalogItem,
         extracted_text: str,
         config: BaseModel,
+        extraction_metadata=None,
     ) -> GraphExtractionResult:
         """
         Extract graph nodes and edges for a single item.
@@ -74,6 +75,7 @@ class CooccurrenceGraphExtractor(GraphExtractor):
         :rtype: GraphExtractionResult
         """
         _ = corpus
+        _ = extraction_metadata
         parsed = config if isinstance(config, CooccurrenceGraphConfig) else None
         if parsed is None:
             parsed = CooccurrenceGraphConfig.model_validate(config)

--- a/src/biblicus/graph/extractors/dependency_relations.py
+++ b/src/biblicus/graph/extractors/dependency_relations.py
@@ -60,6 +60,7 @@ class DependencyRelationsGraphExtractor(GraphExtractor):
         item: CatalogItem,
         extracted_text: str,
         config: BaseModel,
+        extraction_metadata=None,
     ) -> GraphExtractionResult:
         """
         Extract graph nodes and edges for a single item.
@@ -76,6 +77,7 @@ class DependencyRelationsGraphExtractor(GraphExtractor):
         :rtype: GraphExtractionResult
         """
         _ = corpus
+        _ = extraction_metadata
         parsed = config if isinstance(config, DependencyRelationsGraphConfig) else None
         if parsed is None:
             parsed = DependencyRelationsGraphConfig.model_validate(config)

--- a/src/biblicus/graph/extractors/ner_entities.py
+++ b/src/biblicus/graph/extractors/ner_entities.py
@@ -6,14 +6,23 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import Dict, List, Tuple
+from itertools import combinations
+from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from ...corpus import Corpus
 from ...models import CatalogItem
 from ..base import GraphExtractor
+from ..grobid_dedup import (
+    grobid_blocked_surface_forms,
+    grobid_structured_from_metadata,
+    is_grobid_extraction_metadata,
+    should_suppress_ner_entity,
+)
 from ..models import GraphEdge, GraphExtractionResult, GraphNode, GraphSchemaModel
+
+_SPACY_PIPELINE_CACHE: dict[str, object] = {}
 
 
 class NerEntitiesGraphConfig(GraphSchemaModel):
@@ -24,15 +33,31 @@ class NerEntitiesGraphConfig(GraphSchemaModel):
     :vartype model: str
     :ivar min_entity_length: Minimum length for entity labels.
     :vartype min_entity_length: int
+    :ivar max_entity_length: Maximum length for entity labels.
+    :vartype max_entity_length: int
+    :ivar entity_labels: Optional allow-list of spaCy entity labels.
+    :vartype entity_labels: list[str] or None
     :ivar include_item_node: Whether to emit an item node and mentions edges.
     :vartype include_item_node: bool
+    :ivar include_relation_edges: Whether to emit sentence-level entity co-occurrence edges.
+    :vartype include_relation_edges: bool
+    :ivar max_relation_entities_per_sentence: Maximum unique entities per sentence used for
+        co-occurrence edges.
+    :vartype max_relation_entities_per_sentence: int
+    :ivar min_relation_weight: Minimum co-occurrence count needed to emit a relation edge.
+    :vartype min_relation_weight: int
     """
 
     model_config = ConfigDict(extra="forbid")
 
     model: str = Field(min_length=1)
     min_entity_length: int = Field(default=3, ge=1)
+    max_entity_length: int = Field(default=120, ge=1)
+    entity_labels: Optional[List[str]] = Field(default=None)
     include_item_node: bool = Field(default=True)
+    include_relation_edges: bool = Field(default=False)
+    max_relation_entities_per_sentence: int = Field(default=12, ge=2)
+    min_relation_weight: int = Field(default=1, ge=1)
 
 
 class NerEntitiesGraphExtractor(GraphExtractor):
@@ -60,6 +85,7 @@ class NerEntitiesGraphExtractor(GraphExtractor):
         item: CatalogItem,
         extracted_text: str,
         config: BaseModel,
+        extraction_metadata: Optional[Dict[str, Any]] = None,
     ) -> GraphExtractionResult:
         """
         Extract graph nodes and edges for a single item.
@@ -80,13 +106,21 @@ class NerEntitiesGraphExtractor(GraphExtractor):
         if parsed is None:
             parsed = NerEntitiesGraphConfig.model_validate(config)
 
+        grobid_blocked: set[str] | None = None
+        if is_grobid_extraction_metadata(extraction_metadata):
+            structured = grobid_structured_from_metadata(extraction_metadata)
+            grobid_blocked = grobid_blocked_surface_forms(structured)
+
         entities = _extract_entities(
             extracted_text=extracted_text,
             model_name=parsed.model,
             min_length=parsed.min_entity_length,
+            max_length=parsed.max_entity_length,
+            entity_labels=parsed.entity_labels,
+            grobid_blocked_forms=grobid_blocked,
         )
-        entity_counts = Counter(entity for entity, _ in entities)
-        entity_types = {entity: label for entity, label in entities}
+        entity_counts = Counter(entity for entity, _label, _sentence_index in entities)
+        entity_types = {entity: label for entity, label, _sentence_index in entities}
 
         nodes = _build_entity_nodes(entity_counts, entity_types)
         edges: List[GraphEdge] = []
@@ -101,6 +135,15 @@ class NerEntitiesGraphExtractor(GraphExtractor):
             nodes.insert(0, item_node)
             edges.extend(_build_mentions_edges(item_node.node_id, entity_counts))
 
+        if parsed.include_relation_edges:
+            edges.extend(
+                _build_relation_edges(
+                    entities,
+                    max_entities_per_sentence=parsed.max_relation_entities_per_sentence,
+                    min_relation_weight=parsed.min_relation_weight,
+                )
+            )
+
         return GraphExtractionResult(item_id=item.id, nodes=nodes, edges=edges)
 
 
@@ -109,23 +152,66 @@ def _extract_entities(
     extracted_text: str,
     model_name: str,
     min_length: int,
-) -> List[Tuple[str, str]]:
+    max_length: int,
+    entity_labels: Optional[List[str]],
+    grobid_blocked_forms: set[str] | None = None,
+) -> List[Tuple[str, str, int]]:
+    nlp = _load_spacy_pipeline(model_name)
+    doc = nlp(extracted_text)
+    entities: List[Tuple[str, str, int]] = []
+    allowed_labels = set(entity_labels or []) or None
+    for ent in getattr(doc, "ents", []):
+        label = getattr(ent, "label_", "ENTITY")
+        if allowed_labels is not None and label not in allowed_labels:
+            continue
+        text = ent.text.strip()
+        if len(text) < min_length or len(text) > max_length:
+            continue
+        if not _looks_like_entity_label(text):
+            continue
+        if grobid_blocked_forms and should_suppress_ner_entity(
+            label=text,
+            entity_type=label,
+            blocked_forms=grobid_blocked_forms,
+        ):
+            continue
+        entities.append((text, label, _entity_sentence_index(ent)))
+    return entities
+
+
+def _load_spacy_pipeline(model_name: str):
+    cached = _SPACY_PIPELINE_CACHE.get(model_name)
+    if cached is not None:
+        return cached
     try:
         import spacy
     except ImportError as exc:
         raise ValueError(
             "NER graph extraction requires spaCy. Install it with pip install spacy."
         ) from exc
-    nlp = spacy.load(model_name)
-    doc = nlp(extracted_text)
-    entities: List[Tuple[str, str]] = []
-    for ent in getattr(doc, "ents", []):
-        label = getattr(ent, "label_", "ENTITY")
-        text = ent.text.strip()
-        if len(text) < min_length:
-            continue
-        entities.append((text, label))
-    return entities
+    pipeline = spacy.load(model_name)
+    _SPACY_PIPELINE_CACHE[model_name] = pipeline
+    return pipeline
+
+
+def _entity_sentence_index(entity) -> int:
+    try:
+        sent = entity.sent
+        return int(getattr(sent, "start", 0))
+    except Exception:
+        return 0
+
+
+def _looks_like_entity_label(text: str) -> bool:
+    if re.search(r"[\r\n\t]", text):
+        return False
+    if re.search(r",\d|\d[A-Z]", text):
+        return False
+    if re.match(r"^[A-Z]\.\s+[A-Z]", text):
+        return False
+    if not re.search(r"[A-Za-z]", text):
+        return False
+    return re.match(r"^[A-Z][A-Za-z0-9&.,'’/()\- ]*$", text) is not None
 
 
 def _canonicalize(label: str) -> str:
@@ -169,6 +255,42 @@ def _build_mentions_edges(item_node_id: str, entity_counts: Counter[str]) -> Lis
                 edge_type="mentions",
                 weight=float(count),
                 properties={},
+            )
+        )
+    return edges
+
+
+def _build_relation_edges(
+    entities: List[Tuple[str, str, int]],
+    *,
+    max_entities_per_sentence: int,
+    min_relation_weight: int,
+) -> List[GraphEdge]:
+    sentence_entities: Dict[int, List[str]] = {}
+    for label, _entity_type, sentence_index in entities:
+        sentence_entities.setdefault(sentence_index, []).append(_canonicalize(label))
+
+    counts: Counter[tuple[str, str]] = Counter()
+    for canonical_entities in sentence_entities.values():
+        unique_entities = sorted(set(canonical_entities))[:max_entities_per_sentence]
+        for left, right in combinations(unique_entities, 2):
+            counts[(left, right)] += 1
+
+    edges: List[GraphEdge] = []
+    for (left, right), count in sorted(counts.items()):
+        if count < min_relation_weight:
+            continue
+        src = f"entity:{left}"
+        dst = f"entity:{right}"
+        edge_id = f"{src}|related_to|{dst}"
+        edges.append(
+            GraphEdge(
+                edge_id=edge_id,
+                src=src,
+                dst=dst,
+                edge_type="related_to",
+                weight=float(count),
+                properties={"source": "sentence_cooccurrence"},
             )
         )
     return edges

--- a/src/biblicus/graph/extractors/simple_entities.py
+++ b/src/biblicus/graph/extractors/simple_entities.py
@@ -67,6 +67,7 @@ class SimpleEntitiesGraphExtractor(GraphExtractor):
         item: CatalogItem,
         extracted_text: str,
         config: BaseModel,
+        extraction_metadata=None,
     ) -> GraphExtractionResult:
         """
         Extract graph nodes and edges for a single item.
@@ -83,6 +84,7 @@ class SimpleEntitiesGraphExtractor(GraphExtractor):
         :rtype: GraphExtractionResult
         """
         _ = corpus
+        _ = extraction_metadata
         parsed = config if isinstance(config, SimpleEntityGraphConfig) else None
         if parsed is None:
             parsed = self.validate_config(config)

--- a/src/biblicus/graph/grobid_dedup.py
+++ b/src/biblicus/graph/grobid_dedup.py
@@ -1,0 +1,146 @@
+"""
+Helpers for deduplicating spaCy NER output against structured extraction metadata.
+
+Structured metadata may come from GROBID (PDF), LLM HTML extraction, or Papyrus
+urlExtraction attachments.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def is_grobid_extraction_metadata(metadata: dict[str, Any] | None) -> bool:
+    """
+    Return True when extraction metadata indicates GROBID structured parsing ran.
+
+    :param metadata: Per-item extraction metadata from a snapshot artifact.
+    :type metadata: dict[str, object] or None
+    :return: Whether GROBID structured data should be honored.
+    :rtype: bool
+    """
+    if not isinstance(metadata, dict):
+        return False
+    method = str(metadata.get("method") or "").strip().lower()
+    if method in {"grobid", "llm-html", "html-heuristics", "html-heuristics+llm-html", "html-heuristics-partial"}:
+        return True
+    structured = metadata.get("structured")
+    if isinstance(structured, dict) and (
+        structured.get("authors") or structured.get("citations")
+    ):
+        return True
+    # Papyrus reference attachments store a summary under urlExtraction.structured
+    url_extraction = metadata.get("urlExtraction")
+    if isinstance(url_extraction, dict):
+        nested = url_extraction.get("structured")
+        if isinstance(nested, dict) and (nested.get("authors") or nested.get("citations")):
+            return True
+    return False
+
+
+def grobid_structured_from_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    Resolve the structured authors/citations payload from extraction metadata.
+
+    :param metadata: Per-item extraction metadata.
+    :type metadata: dict[str, object] or None
+    :return: Structured payload with authors and citations lists.
+    :rtype: dict[str, object]
+    """
+    if not isinstance(metadata, dict):
+        return {}
+    structured = metadata.get("structured")
+    if isinstance(structured, dict):
+        return structured
+    url_extraction = metadata.get("urlExtraction")
+    if isinstance(url_extraction, dict) and isinstance(url_extraction.get("structured"), dict):
+        return url_extraction["structured"]
+    return {}
+
+
+def grobid_blocked_surface_forms(structured: dict[str, Any]) -> set[str]:
+    """
+    Build normalized surface forms that spaCy should not re-emit after GROBID extraction.
+
+    :param structured: GROBID structured payload with authors[] and citations[].
+    :type structured: dict[str, object]
+    :return: Lowercased normalized tokens and phrases to suppress.
+    :rtype: set[str]
+    """
+    blocked: set[str] = set()
+    authors = structured.get("authors") if isinstance(structured.get("authors"), list) else []
+    for author in authors:
+        if not isinstance(author, dict):
+            continue
+        for key in ("name", "normalized_name"):
+            _add_blocked_phrase(blocked, str(author.get(key) or ""))
+    publication_date = str(structured.get("publication_date") or "").strip()
+    if publication_date:
+        _add_blocked_phrase(blocked, publication_date)
+    publication_date_raw = str(structured.get("publication_date_raw") or "").strip()
+    if publication_date_raw:
+        _add_blocked_phrase(blocked, publication_date_raw)
+    citations = structured.get("citations") if isinstance(structured.get("citations"), list) else []
+    for citation in citations:
+        if not isinstance(citation, dict):
+            continue
+        _add_blocked_phrase(blocked, str(citation.get("title") or ""))
+        _add_blocked_phrase(blocked, str(citation.get("raw") or ""))
+        citation_authors = citation.get("authors")
+        if isinstance(citation_authors, list):
+            for name in citation_authors:
+                _add_blocked_phrase(blocked, str(name or ""))
+    return blocked
+
+
+def should_suppress_ner_entity(
+    *,
+    label: str,
+    entity_type: str,
+    blocked_forms: set[str],
+) -> bool:
+    """
+    Return True when an spaCy entity duplicates GROBID author/citation structure.
+
+    :param label: Entity surface text from spaCy.
+    :type label: str
+    :param entity_type: spaCy entity label (PER, ORG, ...).
+    :type entity_type: str
+    :param blocked_forms: Normalized forms from :func:`grobid_blocked_surface_forms`.
+    :type blocked_forms: set[str]
+    :return: Whether to drop this entity before graph export.
+    :rtype: bool
+    """
+    normalized_label = _normalize_form(label)
+    if not normalized_label:
+        return False
+    if normalized_label in blocked_forms:
+        return True
+    # Author lists often mis-tag surnames as ORG; block any single-token author surname.
+    if entity_type in {"PER", "ORG", "NORP", "PERSON"}:
+        for blocked in blocked_forms:
+            if not blocked or " " in blocked:
+                continue
+            if normalized_label == blocked or normalized_label == _normalize_form(blocked.split()[-1]):
+                return True
+    return False
+
+
+def _add_blocked_phrase(blocked: set[str], value: str) -> None:
+    cleaned = value.strip()
+    if not cleaned:
+        return
+    normalized = _normalize_form(cleaned)
+    if normalized:
+        blocked.add(normalized)
+    for token in re.findall(r"[A-Za-z][A-Za-z0-9\-']*", cleaned):
+        token_norm = _normalize_form(token)
+        if token_norm and len(token_norm) >= 2:
+            blocked.add(token_norm)
+
+
+def _normalize_form(value: str) -> str:
+    lowered = value.strip().lower()
+    normalized = re.sub(r"[^a-z0-9]+", " ", lowered)
+    return re.sub(r"\s+", " ", normalized).strip()

--- a/src/biblicus/graph/models.py
+++ b/src/biblicus/graph/models.py
@@ -253,3 +253,48 @@ class GraphExtractionItemSummary(BaseModel):
     edge_count: int = Field(default=0, ge=0)
     status: str = Field(min_length=1)
     error_message: Optional[str] = None
+    error_reason: Optional[str] = None
+    duration_ms: Optional[int] = Field(default=None, ge=0)
+    attempts: Optional[int] = Field(default=None, ge=1)
+
+
+class GraphExportNode(GraphSchemaModel):
+    """Portable node record exported from a graph snapshot."""
+
+    extractor_id: str = Field(min_length=1)
+    snapshot_id: str = Field(min_length=1)
+    graph_id: str = Field(min_length=1)
+    extraction_snapshot: str = Field(min_length=1)
+    item_id: str = Field(min_length=1)
+    node_id: str = Field(min_length=1)
+    node_type: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    properties: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphExportEdge(GraphSchemaModel):
+    """Portable edge record exported from a graph snapshot."""
+
+    extractor_id: str = Field(min_length=1)
+    snapshot_id: str = Field(min_length=1)
+    graph_id: str = Field(min_length=1)
+    extraction_snapshot: str = Field(min_length=1)
+    item_id: str = Field(min_length=1)
+    edge_id: str = Field(min_length=1)
+    src: str = Field(min_length=1)
+    dst: str = Field(min_length=1)
+    edge_type: str = Field(min_length=1)
+    weight: float = Field(default=1.0)
+    properties: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphSnapshotExport(BaseModel):
+    """Portable export payload for a graph extraction snapshot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot: GraphSnapshotReference
+    manifest: GraphSnapshotManifest
+    nodes: List[GraphExportNode] = Field(default_factory=list)
+    edges: List[GraphExportEdge] = Field(default_factory=list)
+    stats: Dict[str, Any] = Field(default_factory=dict)

--- a/src/biblicus/graph/neo4j.py
+++ b/src/biblicus/graph/neo4j.py
@@ -327,6 +327,174 @@ def _write_nodes(tx, corpus_id: str, graph_id: str, extraction_snapshot: str, it
     )
 
 
+def clear_graph_records(
+    *,
+    driver,
+    settings: Neo4jSettings,
+    corpus_id: str,
+    graph_id: str,
+    extraction_snapshot: str,
+) -> None:
+    """
+    Remove graph nodes and edges for a corpus graph snapshot.
+
+    :param driver: Neo4j driver instance.
+    :param settings: Resolved Neo4j settings.
+    :param corpus_id: Corpus identifier.
+    :param graph_id: Graph identifier.
+    :param extraction_snapshot: Extraction snapshot reference string.
+    """
+    with driver.session(database=settings.database) as session:
+        session.execute_write(
+            _clear_graph_records,
+            corpus_id,
+            graph_id,
+            extraction_snapshot,
+        )
+
+
+def read_graph_records(
+    *,
+    driver,
+    settings: Neo4jSettings,
+    corpus_id: str,
+    graph_id: str,
+    extraction_snapshot: str,
+) -> dict[str, list[dict[str, object]]]:
+    """
+    Read graph nodes and edges for a corpus graph snapshot from Neo4j.
+
+    :return: Mapping with ``nodes`` and ``edges`` record lists.
+    """
+    with driver.session(database=settings.database) as session:
+        node_rows = session.execute_read(
+            _read_nodes,
+            corpus_id,
+            graph_id,
+            extraction_snapshot,
+        )
+        edge_rows = session.execute_read(
+            _read_edges,
+            corpus_id,
+            graph_id,
+            extraction_snapshot,
+        )
+    return {"nodes": node_rows, "edges": edge_rows}
+
+
+def _clear_graph_records(tx, corpus_id: str, graph_id: str, extraction_snapshot: str) -> None:
+    tx.run(
+        """
+        MATCH ()-[r:RELATED {
+            corpus_id: $corpus_id,
+            graph_id: $graph_id,
+            extraction_snapshot_id: $extraction_snapshot
+        }]->()
+        DELETE r
+        """,
+        corpus_id=corpus_id,
+        graph_id=graph_id,
+        extraction_snapshot=extraction_snapshot,
+    )
+    tx.run(
+        """
+        MATCH (n:GraphNode {
+            corpus_id: $corpus_id,
+            graph_id: $graph_id,
+            extraction_snapshot_id: $extraction_snapshot
+        })
+        DELETE n
+        """,
+        corpus_id=corpus_id,
+        graph_id=graph_id,
+        extraction_snapshot=extraction_snapshot,
+    )
+
+
+def _read_nodes(tx, corpus_id: str, graph_id: str, extraction_snapshot: str) -> list[dict[str, object]]:
+    result = tx.run(
+        """
+        MATCH (n:GraphNode {
+            corpus_id: $corpus_id,
+            graph_id: $graph_id,
+            extraction_snapshot_id: $extraction_snapshot
+        })
+        RETURN n.item_id AS item_id,
+               n.node_id AS node_id,
+               n.node_type AS node_type,
+               n.label AS label,
+               n.properties_json AS properties_json
+        ORDER BY item_id, node_id
+        """,
+        corpus_id=corpus_id,
+        graph_id=graph_id,
+        extraction_snapshot=extraction_snapshot,
+    )
+    rows: list[dict[str, object]] = []
+    for record in result:
+        properties_raw = record.get("properties_json")
+        try:
+            properties = json.loads(properties_raw) if properties_raw else {}
+        except json.JSONDecodeError:
+            properties = {}
+        if not isinstance(properties, dict):
+            properties = {}
+        rows.append(
+            {
+                "item_id": record["item_id"],
+                "node_id": record["node_id"],
+                "node_type": record["node_type"],
+                "label": record["label"],
+                "properties": properties,
+            }
+        )
+    return rows
+
+
+def _read_edges(tx, corpus_id: str, graph_id: str, extraction_snapshot: str) -> list[dict[str, object]]:
+    result = tx.run(
+        """
+        MATCH ()-[r:RELATED {
+            corpus_id: $corpus_id,
+            graph_id: $graph_id,
+            extraction_snapshot_id: $extraction_snapshot
+        }]->()
+        RETURN r.item_id AS item_id,
+               r.edge_id AS edge_id,
+               startNode(r).node_id AS src,
+               endNode(r).node_id AS dst,
+               r.edge_type AS edge_type,
+               r.weight AS weight,
+               r.properties_json AS properties_json
+        ORDER BY item_id, edge_id
+        """,
+        corpus_id=corpus_id,
+        graph_id=graph_id,
+        extraction_snapshot=extraction_snapshot,
+    )
+    rows: list[dict[str, object]] = []
+    for record in result:
+        properties_raw = record.get("properties_json")
+        try:
+            properties = json.loads(properties_raw) if properties_raw else {}
+        except json.JSONDecodeError:
+            properties = {}
+        if not isinstance(properties, dict):
+            properties = {}
+        rows.append(
+            {
+                "item_id": record["item_id"],
+                "edge_id": record["edge_id"],
+                "src": record["src"],
+                "dst": record["dst"],
+                "edge_type": record["edge_type"],
+                "weight": record.get("weight", 1.0),
+                "properties": properties,
+            }
+        )
+    return rows
+
+
 def _write_edges(
     tx, corpus_id: str, graph_id: str, extraction_snapshot: str, item_id: str, edges
 ):

--- a/src/biblicus/grobid_client.py
+++ b/src/biblicus/grobid_client.py
@@ -1,0 +1,113 @@
+"""
+Shared GROBID request helpers (concurrency limits and retries).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable, TypeVar
+
+from .url_text import UrlTextExtractionError
+
+T = TypeVar("T")
+
+_GROBID_SEMAPHORE: threading.Semaphore | None = None
+_GROBID_SEMAPHORE_LOCK = threading.Lock()
+
+RETRYABLE_GROBID_ERROR_CODES = frozenset(
+    {
+        "grobid_request_failed",
+        "grobid_http_error",
+        "grobid_unreachable",
+    }
+)
+RETRYABLE_HTTP_STATUSES = frozenset({429, 502, 503, 504})
+
+
+def grobid_max_concurrent_requests() -> int:
+    """
+    Resolve the maximum number of in-flight GROBID HTTP requests.
+
+    :return: Concurrency limit (at least 1).
+    :rtype: int
+    """
+    raw = str(os.environ.get("BIBLICUS_GROBID_MAX_CONCURRENT", "2")).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 2
+    return max(1, value)
+
+
+def grobid_max_retries() -> int:
+    """
+    Resolve how many times to retry a retryable GROBID failure.
+
+    :return: Retry count (at least 1 attempt).
+    :rtype: int
+    """
+    raw = str(os.environ.get("BIBLICUS_GROBID_MAX_RETRIES", "3")).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 3
+    return max(1, value)
+
+
+def _grobid_semaphore() -> threading.Semaphore:
+    global _GROBID_SEMAPHORE
+    with _GROBID_SEMAPHORE_LOCK:
+        if _GROBID_SEMAPHORE is None:
+            _GROBID_SEMAPHORE = threading.Semaphore(grobid_max_concurrent_requests())
+        return _GROBID_SEMAPHORE
+
+
+def is_retryable_grobid_error(exc: UrlTextExtractionError) -> bool:
+    """
+    Return True when a GROBID error is likely transient.
+
+    :param exc: GROBID extraction error.
+    :type exc: UrlTextExtractionError
+    :return: Whether to retry the request.
+    :rtype: bool
+    """
+    if exc.code not in RETRYABLE_GROBID_ERROR_CODES:
+        return False
+    if exc.code == "grobid_http_error":
+        details = exc.details if isinstance(exc.details, dict) else {}
+        status = details.get("http_status")
+        if status is not None and int(status) not in RETRYABLE_HTTP_STATUSES:
+            return False
+    return True
+
+
+def call_grobid_with_limits(operation: Callable[[], T]) -> T:
+    """
+    Run a GROBID HTTP operation with concurrency limiting and retries.
+
+    :param operation: Callable that performs one GROBID request.
+    :type operation: collections.abc.Callable
+    :return: Operation result.
+    :rtype: T
+    :raises UrlTextExtractionError: When all attempts fail.
+    """
+    attempts = grobid_max_retries()
+    last_error: UrlTextExtractionError | None = None
+    from .grobid_runtime import ensure_grobid_running
+
+    with _grobid_semaphore():
+        for attempt in range(1, attempts + 1):
+            try:
+                ensure_grobid_running()
+                return operation()
+            except UrlTextExtractionError as exc:
+                last_error = exc
+                if attempt >= attempts or not is_retryable_grobid_error(exc):
+                    raise
+                backoff = min(8.0, 0.75 * (2 ** (attempt - 1)))
+                time.sleep(backoff)
+    if last_error is not None:
+        raise last_error
+    raise UrlTextExtractionError(code="grobid_request_failed", message="GROBID request failed.")

--- a/src/biblicus/grobid_runtime.py
+++ b/src/biblicus/grobid_runtime.py
@@ -1,0 +1,282 @@
+"""
+Just-in-time GROBID runtime management (Docker auto-start for localhost).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+DEFAULT_GROBID_URL = "http://127.0.0.1:8070"
+DEFAULT_GROBID_DOCKER_IMAGE = "lfoppiano/grobid:0.8.0"
+DEFAULT_GROBID_CONTAINER_NAME = "papyrus-grobid"
+URL_TEXT_GROBID_URL_ENV = "BIBLICUS_GROBID_URL"
+GROBID_AUTO_START_ENV = "BIBLICUS_GROBID_AUTO_START"
+GROBID_CONTAINER_NAME_ENV = "BIBLICUS_GROBID_CONTAINER_NAME"
+GROBID_DOCKER_IMAGE_ENV = "BIBLICUS_GROBID_DOCKER_IMAGE"
+PAPYRUS_GROBID_CONTAINER_NAME_ENV = "PAPYRUS_GROBID_CONTAINER_NAME"
+PAPYRUS_GROBID_DOCKER_IMAGE_ENV = "PAPYRUS_GROBID_DOCKER_IMAGE"
+
+DOCKER_CANDIDATE_PATHS = (
+    "/usr/local/bin/docker",
+    "/opt/homebrew/bin/docker",
+    "/Applications/Docker.app/Contents/Resources/bin/docker",
+)
+
+_ENSURE_LOCK = __import__("threading").Lock()
+_ENSURED_URL: str | None = None
+
+
+def grobid_auto_start_enabled() -> bool:
+    """
+    Return whether localhost GROBID should be auto-started via Docker.
+
+    :return: True when auto-start is enabled.
+    :rtype: bool
+    """
+    raw = os.environ.get(GROBID_AUTO_START_ENV)
+    if raw is not None:
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return True
+
+
+def resolve_grobid_base_url() -> str:
+    """
+    Resolve the GROBID base URL from environment or defaults.
+
+    :return: Base URL without trailing slash.
+    :rtype: str
+    """
+    explicit = (
+        str(os.environ.get(URL_TEXT_GROBID_URL_ENV) or "").strip()
+        or str(os.environ.get("PAPYRUS_GROBID_URL") or "").strip()
+    )
+    if explicit:
+        return explicit.rstrip("/")
+    return DEFAULT_GROBID_URL
+
+
+def ensure_grobid_running(grobid_url: str | None = None) -> str:
+    """
+    Ensure GROBID is reachable, auto-starting a local Docker container when configured.
+
+    :param grobid_url: Optional explicit base URL; defaults to :func:`resolve_grobid_base_url`.
+    :type grobid_url: str or None
+    :return: Verified GROBID base URL.
+    :rtype: str
+    :raises RuntimeError: When GROBID cannot be started or reached.
+    """
+    global _ENSURED_URL
+    base_url = (grobid_url or resolve_grobid_base_url()).rstrip("/")
+    with _ENSURE_LOCK:
+        if _ENSURED_URL == base_url and grobid_is_alive(base_url):
+            return base_url
+        if _ENSURED_URL is not None and not grobid_is_alive(_ENSURED_URL):
+            _ENSURED_URL = None
+        if grobid_is_alive(base_url):
+            _ENSURED_URL = base_url
+            return base_url
+        if not grobid_auto_start_enabled():
+            raise RuntimeError(
+                f"GROBID is not reachable at {base_url} and {GROBID_AUTO_START_ENV} is disabled."
+            )
+        parsed = urlparse(base_url)
+        host = (parsed.hostname or "").strip().lower()
+        port = int(parsed.port or (443 if parsed.scheme == "https" else 80))
+        if host not in {"127.0.0.1", "localhost"}:
+            raise RuntimeError(
+                f"GROBID is not reachable at {base_url}. Auto-start is only supported for localhost endpoints."
+            )
+        _start_or_reuse_local_grobid_container(port=port)
+        _await_grobid_ready(base_url)
+        _ENSURED_URL = base_url
+        return base_url
+
+
+def grobid_is_alive(grobid_url: str) -> bool:
+    """
+    Probe GROBID ``/api/isalive``.
+
+    :param grobid_url: GROBID base URL.
+    :type grobid_url: str
+    :return: True when the service responds successfully.
+    :rtype: bool
+    """
+    probe_url = f"{grobid_url.rstrip('/')}/api/isalive"
+    request = Request(probe_url, method="GET")
+    try:
+        with urlopen(request, timeout=2.0) as response:
+            status = int(getattr(response, "status", response.getcode()))
+            if status < 200 or status >= 300:
+                return False
+            payload = response.read().decode("utf-8", errors="replace").strip().lower()
+            return "true" in payload or payload == ""
+    except Exception:
+        return False
+
+
+def _grobid_container_name() -> str:
+    return (
+        str(os.environ.get(GROBID_CONTAINER_NAME_ENV) or "").strip()
+        or str(os.environ.get(PAPYRUS_GROBID_CONTAINER_NAME_ENV) or "").strip()
+        or DEFAULT_GROBID_CONTAINER_NAME
+    )
+
+
+def _grobid_docker_image() -> str:
+    return (
+        str(os.environ.get(GROBID_DOCKER_IMAGE_ENV) or "").strip()
+        or str(os.environ.get(PAPYRUS_GROBID_DOCKER_IMAGE_ENV) or "").strip()
+        or DEFAULT_GROBID_DOCKER_IMAGE
+    )
+
+
+def _port_is_open(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1.0)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _start_or_reuse_local_grobid_container(*, port: int) -> None:
+    docker_command = _resolve_docker_command()
+    if not docker_command:
+        raise RuntimeError(
+            "Docker binary was not found. Cannot auto-start local GROBID container. "
+            "Install Docker Desktop/CLI or point BIBLICUS_GROBID_URL at a reachable service."
+        )
+    _ensure_docker_daemon_ready(docker_command)
+
+    container_name = _grobid_container_name()
+    image = _grobid_docker_image()
+    running = _docker_lines(
+        docker_command,
+        [
+            "ps",
+            "--filter",
+            f"name=^/{container_name}$",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.ID}}",
+        ],
+    )
+    if running:
+        return
+
+    existing = _docker_lines(
+        docker_command,
+        [
+            "ps",
+            "-a",
+            "--filter",
+            f"name=^/{container_name}$",
+            "--format",
+            "{{.ID}}",
+        ],
+    )
+    if existing:
+        completed = subprocess.run(
+            [docker_command, "start", container_name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            stderr = (completed.stderr or completed.stdout or "").strip()
+            raise RuntimeError(f"Failed to start existing GROBID container {container_name}: {stderr}")
+        return
+
+    completed = subprocess.run(
+        [
+            docker_command,
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "-p",
+            f"{port}:8070",
+            image,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or completed.stdout or "").strip()
+        raise RuntimeError(f"Failed to launch GROBID container {container_name} using {image}: {stderr}")
+
+
+def _await_grobid_ready(grobid_url: str) -> None:
+    deadline = time.time() + 120.0
+    parsed = urlparse(grobid_url)
+    host = (parsed.hostname or "127.0.0.1").strip()
+    port = int(parsed.port or (443 if parsed.scheme == "https" else 80))
+    while time.time() < deadline:
+        if _port_is_open(host, port) and grobid_is_alive(grobid_url):
+            return
+        time.sleep(1.5)
+    raise RuntimeError(
+        f"GROBID did not become ready at {grobid_url} after container start. "
+        "Check Docker container logs and retry."
+    )
+
+
+def _resolve_docker_command() -> str | None:
+    command = shutil.which("docker")
+    if command:
+        return command
+    for candidate in DOCKER_CANDIDATE_PATHS:
+        if Path(candidate).is_file():
+            return candidate
+    return None
+
+
+def _docker_daemon_ready(docker_command: str) -> bool:
+    completed = subprocess.run(
+        [docker_command, "info"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _ensure_docker_daemon_ready(docker_command: str) -> None:
+    if _docker_daemon_ready(docker_command):
+        return
+    if sys.platform == "darwin" and Path("/Applications/Docker.app").exists():
+        subprocess.run(
+            ["open", "-a", "Docker"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        deadline = time.time() + 90.0
+        while time.time() < deadline:
+            if _docker_daemon_ready(docker_command):
+                return
+            time.sleep(1.5)
+    raise RuntimeError(
+        "Docker daemon is not ready for GROBID auto-start. "
+        "Start Docker Desktop and retry, or point BIBLICUS_GROBID_URL at a reachable service."
+    )
+
+
+def _docker_lines(docker_command: str, command: List[str]) -> List[str]:
+    completed = subprocess.run(
+        [docker_command, *command],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return []
+    return [line.strip() for line in (completed.stdout or "").splitlines() if line.strip()]

--- a/src/biblicus/html_heuristics.py
+++ b/src/biblicus/html_heuristics.py
@@ -1,0 +1,719 @@
+"""
+Heuristic structured metadata extraction from HTML using BeautifulSoup.
+
+Extracts article metadata and bibliography candidates from common markup patterns
+(JSON-LD, Open Graph, meta tags, reference sections, footer links) before optional
+LLM refinement.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
+
+REFERENCE_HEADING_RE = re.compile(
+    r"\b(references|bibliography|sources|citations|works\s+cited|further\s+reading)\b",
+    re.IGNORECASE,
+)
+YEAR_RE = re.compile(r"\b(19|20)\d{2}\b")
+DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+\b", re.IGNORECASE)
+BYLINE_CLASS_RE = re.compile(r"\b(byline|author|writers?)\b", re.IGNORECASE)
+JSON_LD_ARTICLE_TYPES = {
+    "article",
+    "newsarticle",
+    "blogposting",
+    "scholarlyarticle",
+    "report",
+    "techarticle",
+}
+FOOTER_BOTTOM_FRACTION = 0.25
+
+
+@dataclass
+class HtmlHeuristicDocument:
+    """
+  Parsed heuristic document payload.
+
+  :ivar source_uri: Page URL when known.
+  :vartype source_uri: str
+  :ivar title: Resolved article title.
+  :vartype title: str or None
+  :ivar authors: Author rows with name and normalized_name.
+  :vartype authors: list[dict[str, str]]
+  :ivar publication_date: ISO date when resolved (YYYY-MM-DD).
+  :vartype publication_date: str or None
+  :ivar publication_date_raw: Verbatim date string from markup.
+  :vartype publication_date_raw: str or None
+  :ivar updated_at: ISO date for last update when known.
+  :vartype updated_at: str or None
+  :ivar body_html: Main article HTML subset when detected.
+  :vartype body_html: str
+  :ivar body_text: Plain text from body_html.
+  :vartype body_text: str
+  :ivar links: External link candidates with anchor text.
+  :vartype links: list[dict[str, str]]
+  :ivar reference_candidates: Unnormalized bibliography rows.
+  :vartype reference_candidates: list[dict[str, Any]]
+  :ivar citations: GROBID-shaped bibliography entries.
+  :vartype citations: list[dict[str, Any]]
+  :ivar raw_metadata: Layered extraction provenance.
+  :vartype raw_metadata: dict[str, Any]
+  :ivar warnings: Non-fatal extraction warnings.
+  :vartype warnings: list[dict[str, str]]
+  :ivar layers: Ordered layer ids that contributed fields.
+  :vartype layers: list[str]
+    """
+
+    source_uri: str = ""
+    title: Optional[str] = None
+    authors: List[Dict[str, str]] = field(default_factory=list)
+    publication_date: Optional[str] = None
+    publication_date_raw: Optional[str] = None
+    updated_at: Optional[str] = None
+    body_html: str = ""
+    body_text: str = ""
+    links: List[Dict[str, str]] = field(default_factory=list)
+    reference_candidates: List[Dict[str, Any]] = field(default_factory=list)
+    citations: List[Dict[str, Any]] = field(default_factory=list)
+    raw_metadata: Dict[str, Any] = field(default_factory=dict)
+    warnings: List[Dict[str, str]] = field(default_factory=list)
+    layers: List[str] = field(default_factory=list)
+
+
+def extract_html_heuristics(
+    html: str,
+    *,
+    source_uri: str = "",
+    footer_link_fraction: float = FOOTER_BOTTOM_FRACTION,
+) -> HtmlHeuristicDocument:
+    """
+    Parse HTML and extract structured metadata using layered heuristics.
+
+    :param html: Raw HTML document.
+    :type html: str
+    :param source_uri: Optional canonical page URL for resolving relative links.
+    :type source_uri: str
+    :param footer_link_fraction: Bottom fraction of DOM used for link harvesting.
+    :type footer_link_fraction: float
+    :return: Heuristic document payload.
+    :rtype: HtmlHeuristicDocument
+    :raises ValueError: If BeautifulSoup is not installed.
+    """
+    soup = _build_soup(html)
+    doc = HtmlHeuristicDocument(source_uri=str(source_uri or "").strip())
+    raw: Dict[str, Any] = {}
+
+    json_ld_rows = _extract_json_ld(soup)
+    if json_ld_rows:
+        raw["json_ld"] = json_ld_rows
+        _merge_json_ld(doc, json_ld_rows)
+
+    og = _extract_open_graph(soup)
+    if og:
+        raw["open_graph"] = og
+        _merge_open_graph(doc, og)
+
+    twitter = _extract_twitter_cards(soup)
+    if twitter:
+        raw["twitter_card"] = twitter
+        _merge_twitter(doc, twitter)
+
+    html_meta = _extract_html_meta(soup)
+    if html_meta:
+        raw["html_meta"] = html_meta
+        _merge_html_meta(doc, html_meta)
+
+    byline = _extract_byline_authors(soup)
+    if byline:
+        raw["byline"] = byline
+        _merge_authors(doc, byline, layer="html_byline")
+
+    _extract_body(soup, doc)
+
+    reference_candidates = _extract_reference_section_candidates(soup, source_uri=doc.source_uri)
+    footer_candidates = _extract_footer_link_candidates(
+        soup,
+        source_uri=doc.source_uri,
+        bottom_fraction=footer_link_fraction,
+    )
+    footer_node = soup.find("footer")
+    if footer_node is not None:
+        footer_candidates.extend(
+            _extract_link_candidates_from_node(
+                footer_node,
+                source_uri=doc.source_uri,
+                source_label="footer_element",
+            )
+        )
+        if "footer_element" not in doc.layers:
+            doc.layers.append("footer_element")
+    doc.reference_candidates = _dedupe_reference_candidates(reference_candidates + footer_candidates)
+    if doc.reference_candidates:
+        raw["reference_candidates"] = doc.reference_candidates
+        if "reference_section" not in doc.layers and reference_candidates:
+            doc.layers.append("reference_section")
+        if footer_candidates and "footer_links" not in doc.layers:
+            doc.layers.append("footer_links")
+
+    doc.citations = _normalize_reference_candidates(doc.reference_candidates)
+    doc.links = [
+        {
+            "href": str(row.get("url") or ""),
+            "text": str(row.get("title") or row.get("raw") or ""),
+            "source": str(row.get("source") or ""),
+        }
+        for row in doc.reference_candidates
+        if str(row.get("url") or "").strip()
+    ]
+    doc.raw_metadata = raw
+
+    if not doc.title:
+        doc.warnings.append(
+            {"code": "title_missing", "message": "No article title found in heuristic layers."}
+        )
+    if not doc.authors:
+        doc.warnings.append(
+            {"code": "authors_missing", "message": "No authors found in heuristic layers."}
+        )
+    if not doc.citations:
+        doc.warnings.append(
+            {
+                "code": "citations_missing",
+                "message": "No bibliography candidates normalized from heuristic layers.",
+            }
+        )
+    return doc
+
+
+def heuristic_document_to_structured(doc: HtmlHeuristicDocument) -> Dict[str, Any]:
+    """
+    Convert a heuristic document into GROBID-shaped structured metadata.
+
+    :param doc: Parsed heuristic document.
+    :type doc: HtmlHeuristicDocument
+    :return: Structured payload for graph/citation ingestion.
+    :rtype: dict[str, Any]
+    """
+    citations_with_identifiers = sum(
+        1
+        for citation in doc.citations
+        if any(str(citation.get(key) or "").strip() for key in ("doi", "arxiv_id", "isbn", "url"))
+    )
+    return {
+        "authors": list(doc.authors),
+        "citations": list(doc.citations),
+        "publication_date": doc.publication_date,
+        "publication_date_raw": doc.publication_date_raw,
+        "updated_at": doc.updated_at,
+        "title": doc.title,
+        "summary": {
+            "authors_count": len(doc.authors),
+            "citations_count": len(doc.citations),
+            "citations_with_identifiers": citations_with_identifiers,
+            "reference_candidates_count": len(doc.reference_candidates),
+        },
+        "warnings": list(doc.warnings),
+        "raw_metadata": dict(doc.raw_metadata),
+        "layers": list(doc.layers),
+    }
+
+
+def structured_metadata_is_sufficient(structured: Dict[str, Any] | None) -> bool:
+    """
+    Return True when heuristic structured metadata is strong enough to skip LLM.
+
+    :param structured: GROBID-shaped structured dict.
+    :type structured: dict[str, object] or None
+    :return: Whether LLM fallback can be skipped.
+    :rtype: bool
+    """
+    if not isinstance(structured, dict):
+        return False
+    authors = structured.get("authors") if isinstance(structured.get("authors"), list) else []
+    citations = structured.get("citations") if isinstance(structured.get("citations"), list) else []
+    if authors and structured.get("publication_date"):
+        return True
+    if not citations:
+        return bool(authors)
+    strong_citations = 0
+    for entry in citations:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("doi") or "").strip() or str(entry.get("url") or "").strip():
+            strong_citations += 1
+            continue
+        title = str(entry.get("title") or "").strip()
+        year = entry.get("year")
+        author_count = len(entry.get("authors") or []) if isinstance(entry.get("authors"), list) else 0
+        if len(title) >= 12 and year is not None and author_count >= 1:
+            strong_citations += 1
+    return strong_citations >= 1 or (len(citations) >= 3 and authors)
+
+
+def _build_soup(html: str) -> Any:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:
+        raise ValueError(
+            "HTML heuristic extraction requires beautifulsoup4. "
+            'Install it with pip install "biblicus[web]".'
+        ) from exc
+    parser = "lxml"
+    try:
+        import lxml  # noqa: F401
+    except ImportError:
+        parser = "html.parser"
+    return BeautifulSoup(str(html or ""), parser)
+
+
+def _extract_json_ld(soup: Any) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for node in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = _normalize_inline_text(node.string or node.get_text() or "")
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        for item in _flatten_json_ld(payload):
+            if isinstance(item, dict):
+                rows.append(item)
+    return rows
+
+
+def _flatten_json_ld(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        rows: List[Dict[str, Any]] = []
+        for entry in payload:
+            rows.extend(_flatten_json_ld(entry))
+        return rows
+    if not isinstance(payload, dict):
+        return []
+    graph = payload.get("@graph")
+    if isinstance(graph, list):
+        return [entry for entry in graph if isinstance(entry, dict)]
+    return [payload]
+
+
+def _merge_json_ld(doc: HtmlHeuristicDocument, rows: List[Dict[str, Any]]) -> None:
+    for row in rows:
+        types = _json_ld_types(row)
+        if not types & JSON_LD_ARTICLE_TYPES:
+            continue
+        if not doc.title:
+            doc.title = _first_non_empty(
+                [
+                    row.get("headline"),
+                    row.get("name"),
+                    row.get("alternativeHeadline"),
+                ]
+            )
+        _merge_authors(doc, _json_ld_authors(row), layer="json_ld")
+        published = _first_non_empty([row.get("datePublished"), row.get("dateCreated")])
+        if published and not doc.publication_date:
+            doc.publication_date_raw = published
+            doc.publication_date = _normalize_date_token(published)
+            doc.layers.append("json_ld")
+        modified = _first_non_empty([row.get("dateModified"), row.get("dateUpdated")])
+        if modified and not doc.updated_at:
+            doc.updated_at = _normalize_date_token(modified)
+    if doc.layers and "json_ld" not in doc.layers:
+        doc.layers.append("json_ld")
+
+
+def _json_ld_types(row: Dict[str, Any]) -> set[str]:
+    raw_type = row.get("@type")
+    tokens: List[str] = []
+    if isinstance(raw_type, str):
+        tokens = [raw_type]
+    elif isinstance(raw_type, list):
+        tokens = [str(entry) for entry in raw_type]
+    return {token.split("/")[-1].lower() for token in tokens}
+
+
+def _json_ld_authors(row: Dict[str, Any]) -> List[str]:
+    authors: List[str] = []
+    author_value = row.get("author")
+    if isinstance(author_value, list):
+        for entry in author_value:
+            authors.extend(_json_ld_author_names(entry))
+    else:
+        authors.extend(_json_ld_author_names(author_value))
+    return authors
+
+
+def _json_ld_author_names(value: Any) -> List[str]:
+    if isinstance(value, str):
+        name = _normalize_inline_text(value)
+        return [name] if name else []
+    if not isinstance(value, dict):
+        return []
+    name = _first_non_empty([value.get("name"), value.get("givenName"), value.get("familyName")])
+    if name:
+        return [name]
+    return []
+
+
+def _extract_open_graph(soup: Any) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for meta in soup.find_all("meta"):
+        prop = str(meta.get("property") or meta.get("name") or "").strip().lower()
+        content = _normalize_inline_text(str(meta.get("content") or ""))
+        if not prop or not content:
+            continue
+        if prop in {
+            "og:title",
+            "og:description",
+            "article:published_time",
+            "article:modified_time",
+            "article:author",
+            "og:article:author",
+            "og:article:published_time",
+        }:
+            values[prop] = content
+    return values
+
+
+def _merge_open_graph(doc: HtmlHeuristicDocument, og: Dict[str, str]) -> None:
+    if not doc.title and og.get("og:title"):
+        doc.title = og["og:title"]
+    published = og.get("article:published_time") or og.get("og:article:published_time")
+    if published and not doc.publication_date:
+        doc.publication_date_raw = published
+        doc.publication_date = _normalize_date_token(published)
+    modified = og.get("article:modified_time")
+    if modified and not doc.updated_at:
+        doc.updated_at = _normalize_date_token(modified)
+    author = og.get("article:author") or og.get("og:article:author")
+    if author:
+        _merge_authors(doc, [author], layer="open_graph")
+
+
+def _extract_twitter_cards(soup: Any) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for meta in soup.find_all("meta"):
+        name = str(meta.get("name") or "").strip().lower()
+        content = _normalize_inline_text(str(meta.get("content") or ""))
+        if name.startswith("twitter:") and content:
+            values[name] = content
+    return values
+
+
+def _merge_twitter(doc: HtmlHeuristicDocument, twitter: Dict[str, str]) -> None:
+    if not doc.title:
+        doc.title = twitter.get("twitter:title") or doc.title
+    creator = twitter.get("twitter:creator")
+    if creator:
+        cleaned = creator.lstrip("@").strip()
+        if cleaned:
+            _merge_authors(doc, [cleaned], layer="twitter_card")
+
+
+def _extract_html_meta(soup: Any) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    title_node = soup.find("title")
+    if title_node:
+        title = _normalize_inline_text(title_node.get_text())
+        if title:
+            values["html_title"] = title
+    for meta in soup.find_all("meta"):
+        name = str(meta.get("name") or "").strip().lower()
+        content = _normalize_inline_text(str(meta.get("content") or ""))
+        if name == "author" and content:
+            values["meta_author"] = content
+        if name in {"dc.date", "dcterms.created", "citation_publication_date"} and content:
+            values.setdefault("meta_date", content)
+    return values
+
+
+def _merge_html_meta(doc: HtmlHeuristicDocument, html_meta: Dict[str, str]) -> None:
+    if not doc.title and html_meta.get("html_title"):
+        doc.title = html_meta["html_title"]
+    if html_meta.get("meta_author"):
+        _merge_authors(doc, [html_meta["meta_author"]], layer="html_meta")
+    if html_meta.get("meta_date") and not doc.publication_date:
+        doc.publication_date_raw = html_meta["meta_date"]
+        doc.publication_date = _normalize_date_token(html_meta["meta_date"])
+        if "html_meta" not in doc.layers:
+            doc.layers.append("html_meta")
+
+
+def _extract_byline_authors(soup: Any) -> List[str]:
+    names: List[str] = []
+    for node in soup.find_all(True, class_=BYLINE_CLASS_RE):
+        text = _normalize_inline_text(node.get_text(" ", strip=True))
+        if text and len(text) <= 120:
+            names.append(text)
+    for node in soup.find_all(["header", "article"]):
+        for child in node.find_all(["p", "span", "div"], limit=40):
+            classes = " ".join(child.get("class") or []).lower()
+            if "byline" not in classes and "author" not in classes:
+                continue
+            text = _normalize_inline_text(child.get_text(" ", strip=True))
+            if text and len(text) <= 120:
+                names.append(text)
+    return names
+
+
+def _extract_body(soup: Any, doc: HtmlHeuristicDocument) -> None:
+    article = soup.find("article") or soup.find("main") or soup.body
+    if article is None:
+        return
+    doc.body_html = str(article)
+    doc.body_text = _normalize_block_text(article.get_text("\n", strip=True))
+
+
+def _extract_reference_section_candidates(soup: Any, *, source_uri: str) -> List[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+    for heading in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"]):
+        label = _normalize_inline_text(heading.get_text())
+        if not label or not REFERENCE_HEADING_RE.search(label):
+            continue
+        for list_node in _reference_lists_after_heading(heading):
+            for item in list_node.find_all("li", recursive=False):
+                raw = _normalize_inline_text(item.get_text(" ", strip=True))
+                if not raw:
+                    continue
+                link = item.find("a", href=True)
+                href = _resolve_href(str(link.get("href") or ""), source_uri) if link else None
+                candidates.append(
+                    {
+                        "source": "reference_section",
+                        "raw": raw,
+                        "title": _guess_title_from_reference_line(raw),
+                        "url": href,
+                        "heading": label,
+                    }
+                )
+    return candidates
+
+
+def _reference_lists_after_heading(heading: Any) -> List[Any]:
+    lists: List[Any] = []
+    for sibling in heading.find_all_next(["ol", "ul"], limit=3):
+        parent_heading = sibling.find_previous(["h1", "h2", "h3", "h4", "h5", "h6"])
+        if parent_heading is heading:
+            lists.append(sibling)
+    return lists
+
+
+def _extract_link_candidates_from_node(
+    node: Any,
+    *,
+    source_uri: str,
+    source_label: str,
+) -> List[Dict[str, Any]]:
+    source_host = (urlparse(source_uri).netloc or "").lower()
+    candidates: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for anchor in node.find_all("a", href=True):
+        href = _resolve_href(str(anchor.get("href") or ""), source_uri)
+        if not href or not href.startswith("http"):
+            continue
+        host = (urlparse(href).netloc or "").lower()
+        if source_host and host == source_host:
+            continue
+        text = _normalize_inline_text(anchor.get_text(" ", strip=True))
+        if not text or len(text) < 4:
+            continue
+        key = f"{href}|{text.lower()}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            {
+                "source": source_label,
+                "raw": text,
+                "title": text,
+                "url": href,
+            }
+        )
+    return candidates
+
+
+def _extract_footer_link_candidates(
+    soup: Any,
+    *,
+    source_uri: str,
+    bottom_fraction: float,
+) -> List[Dict[str, Any]]:
+    body = soup.body
+    if body is None:
+        return []
+    all_nodes = list(body.find_all(True))
+    if not all_nodes:
+        return []
+    start_index = int(len(all_nodes) * (1.0 - max(0.05, min(bottom_fraction, 0.5))))
+    bottom_nodes = all_nodes[start_index:]
+    candidates: List[Dict[str, Any]] = []
+    for node in bottom_nodes:
+        candidates.extend(
+            _extract_link_candidates_from_node(
+                node,
+                source_uri=source_uri,
+                source_label="footer_links",
+            )
+        )
+    return candidates
+
+
+def _normalize_reference_candidates(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        raw = str(candidate.get("raw") or "").strip()
+        title = str(candidate.get("title") or raw).strip()
+        if not title:
+            continue
+        key = title.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        year_match = YEAR_RE.search(raw)
+        year = int(year_match.group(0)) if year_match else None
+        doi_match = DOI_RE.search(raw)
+        authors = _guess_authors_from_reference_line(raw)
+        rows.append(
+            {
+                "title": title[:500] or None,
+                "authors": authors,
+                "year": year,
+                "venue": None,
+                "doi": doi_match.group(0) if doi_match else None,
+                "arxiv_id": None,
+                "isbn": None,
+                "url": str(candidate.get("url") or "").strip() or None,
+                "raw": raw or None,
+                "citing_context": None,
+                "candidate_source": str(candidate.get("source") or ""),
+            }
+        )
+    return rows
+
+
+def _dedupe_reference_candidates(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    deduped: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        raw = str(candidate.get("raw") or "").strip().lower()
+        url = str(candidate.get("url") or "").strip().lower()
+        key = url or raw
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def _merge_authors(doc: HtmlHeuristicDocument, names: List[str], *, layer: str) -> None:
+    existing = {row.get("normalized_name") for row in doc.authors if isinstance(row, dict)}
+    expanded: List[str] = []
+    for name in names:
+        cleaned = _normalize_inline_text(name)
+        if not cleaned:
+            continue
+        if re.search(r"\s+and\s+", cleaned, flags=re.IGNORECASE):
+            expanded.extend(
+                part.strip()
+                for part in re.split(r"\s+and\s+", cleaned, flags=re.IGNORECASE)
+                if part.strip()
+            )
+        else:
+            expanded.append(cleaned)
+    for cleaned in expanded:
+        normalized = _normalize_person_name(cleaned)
+        if normalized in existing:
+            continue
+        existing.add(normalized)
+        doc.authors.append({"name": cleaned, "normalized_name": normalized})
+    if expanded and layer not in doc.layers:
+        doc.layers.append(layer)
+
+
+def _guess_title_from_reference_line(raw: str) -> str:
+    text = _normalize_inline_text(raw)
+    if not text:
+        return ""
+    without_year = YEAR_RE.sub("", text).strip(" .,;")
+    parts = re.split(r"\.\s+", without_year)
+    if len(parts) >= 2 and len(parts[-1]) >= 8:
+        return parts[-1].strip()
+    return text[:240]
+
+
+def _guess_authors_from_reference_line(raw: str) -> List[str]:
+    text = _normalize_inline_text(raw)
+    if not text:
+        return []
+    head = text.split(".", 1)[0]
+    if len(head) > 120:
+        return []
+    if " et al" in head.lower():
+        head = head.split(" et al", 1)[0]
+    if "," in head and len(head.split(",")) <= 4:
+        return [part.strip() for part in head.split(",") if part.strip()]
+    if " and " in head.lower():
+        return [part.strip() for part in re.split(r"\s+and\s+", head, flags=re.IGNORECASE) if part.strip()]
+    return [head] if 2 <= len(head) <= 80 else []
+
+
+def _resolve_href(href: str, source_uri: str) -> Optional[str]:
+    token = str(href or "").strip()
+    if not token or token.startswith("#"):
+        return None
+    if token.startswith("http://") or token.startswith("https://"):
+        return token
+    if source_uri:
+        return urljoin(source_uri, token)
+    return token
+
+
+def _normalize_date_token(value: str) -> Optional[str]:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    if token.endswith("Z"):
+        token = token[:-1]
+    if "T" in token:
+        token = token.split("T", 1)[0]
+    normalized = token.replace("/", "-")
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", normalized):
+        return normalized
+    if re.fullmatch(r"\d{4}-\d{2}", normalized):
+        return f"{normalized}-01"
+    year_match = re.fullmatch(r"(\d{4})", normalized)
+    if year_match:
+        return f"{year_match.group(1)}-01-01"
+    return None
+
+
+def _normalize_person_name(value: str) -> str:
+    tokens = [token for token in _normalize_inline_text(value).split(" ") if token]
+    if not tokens:
+        return ""
+    if len(tokens) == 1:
+        return tokens[0].lower()
+    return f"{tokens[-1].lower()} {' '.join(token.lower() for token in tokens[:-1])}".strip()
+
+
+def _normalize_inline_text(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _normalize_block_text(value: str) -> str:
+    lines = [line.strip() for line in str(value or "").splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def _first_non_empty(values: List[Any]) -> str:
+    for value in values:
+        token = _normalize_inline_text(str(value or ""))
+        if token:
+            return token
+    return ""

--- a/src/biblicus/html_structured.py
+++ b/src/biblicus/html_structured.py
@@ -1,0 +1,464 @@
+"""
+LLM-guided structured metadata extraction for HTML web articles.
+
+Uses a single multi-turn conversation (authors, publication date, bibliography)
+so later turns can reuse cached context. Output matches GROBID-shaped structured
+payloads used by spaCy dedup and Papyrus citation ingestion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional
+
+from .ai.models import LlmClientConfig
+
+HTML_STRUCTURED_PROMPT_VERSION = "html-structured-v1"
+HTML_STRUCTURED_DEFAULT_MODEL = "gpt-5.4-nano"
+HTML_STRUCTURED_MAX_ARTICLE_CHARS = 120_000
+HTML_STRUCTURED_ENABLE_ENV = "BIBLICUS_HTML_LLM_STRUCTURED"
+
+
+def html_llm_structured_enabled() -> bool:
+    """
+    Return whether LLM HTML structured extraction should run.
+
+    :return: True unless explicitly disabled via environment.
+    :rtype: bool
+    """
+    raw = str(os.environ.get(HTML_STRUCTURED_ENABLE_ENV) or "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def enrich_web_extraction_with_llm_structured(
+    converted: Dict[str, Any],
+    *,
+    source_uri: str,
+    html_content: str = "",
+    reference_title: str = "",
+    model: str = HTML_STRUCTURED_DEFAULT_MODEL,
+    completion_resolver: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """
+    Attach GROBID-shaped structured metadata to a markitdown web extraction result.
+
+    :param converted: Markitdown conversion payload with text/markdown/title.
+    :type converted: dict[str, Any]
+    :param source_uri: Article URL.
+    :type source_uri: str
+    :param html_content: Raw HTML when available; otherwise markdown/text is used.
+    :type html_content: str
+    :param reference_title: Optional reference title hint.
+    :type reference_title: str
+    :param model: OpenAI model identifier.
+    :type model: str
+    :param completion_resolver: Optional test hook for JSON completions.
+    :type completion_resolver: Callable[..., dict[str, Any]] or None
+    :return: Updated conversion payload.
+    :rtype: dict[str, Any]
+    """
+    if not html_llm_structured_enabled():
+        return converted
+    article_body = str(html_content or "").strip()
+    if not article_body:
+        article_body = str(converted.get("markdown") or converted.get("text") or "").strip()
+    if not article_body:
+        return converted
+
+    try:
+        structured, llm_meta = extract_html_structured_metadata(
+            article_content=article_body,
+            content_kind="html" if str(html_content or "").strip() else "markdown",
+            source_uri=source_uri,
+            page_title=str(converted.get("title") or "").strip(),
+            reference_title=reference_title,
+            model=model,
+            completion_resolver=completion_resolver,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via tests with resolver
+        warnings = converted.get("llm_structured_warnings")
+        if not isinstance(warnings, list):
+            warnings = []
+        warnings.append(
+            {
+                "code": "llm_structured_failed",
+                "message": str(exc),
+            }
+        )
+        return {**converted, "llm_structured_warnings": warnings}
+
+    if (
+        not structured.get("authors")
+        and not structured.get("citations")
+        and not structured.get("publication_date")
+    ):
+        return converted
+
+    return {
+        **converted,
+        "method": "llm-html",
+        "structured": structured,
+        "llm_structured": llm_meta,
+    }
+
+
+def extract_html_structured_metadata(
+    *,
+    article_content: str,
+    content_kind: str,
+    source_uri: str,
+    page_title: str = "",
+    reference_title: str = "",
+    model: str = HTML_STRUCTURED_DEFAULT_MODEL,
+    completion_resolver: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Run the three-turn LLM structured extraction conversation.
+
+    :param article_content: HTML or markdown article body.
+    :type article_content: str
+    :param content_kind: ``html`` or ``markdown``.
+    :type content_kind: str
+    :param source_uri: Source URL.
+    :type source_uri: str
+    :param page_title: Extracted page title if known.
+    :type page_title: str
+    :param reference_title: Optional reference title hint.
+    :type reference_title: str
+    :param model: OpenAI model identifier.
+    :type model: str
+    :param completion_resolver: Optional resolver for JSON completions.
+    :type completion_resolver: Callable[..., dict[str, Any]] or None
+    :return: Tuple of structured payload and LLM provenance metadata.
+    :rtype: tuple[dict[str, Any], dict[str, Any]]
+    """
+    resolver = completion_resolver or _openai_json_completion
+    clip = _clip_article(article_content)
+    clipped_text = str(clip["text"])
+    messages: List[Dict[str, str]] = [
+        {
+            "role": "system",
+            "content": (
+                "You extract bibliographic structure from web articles. "
+                "Use only the provided article content. "
+                "Return strict JSON objects when asked; do not invent references."
+            ),
+        },
+        {
+            "role": "user",
+            "content": _initial_article_prompt(
+                source_uri=source_uri,
+                page_title=page_title,
+                reference_title=reference_title,
+                content_kind=content_kind,
+                article_content=clipped_text,
+            ),
+        },
+    ]
+
+    authors_payload = resolver(
+        model=model,
+        messages=[
+            *messages,
+            {
+                "role": "user",
+                "content": (
+                    "From this article, list the author names of the article itself "
+                    "(not cited works). Return JSON: "
+                    '{"authors":[{"name":"Full Name","normalized_name":"family given"}]}. '
+                    "Use an empty authors array when unknown."
+                ),
+            },
+        ],
+    )
+    messages.append(
+        {
+            "role": "assistant",
+            "content": json.dumps(authors_payload, ensure_ascii=False),
+        }
+    )
+
+    date_payload = resolver(
+        model=model,
+        messages=[
+            *messages,
+            {
+                "role": "user",
+                "content": (
+                    "What is this article's publication date? "
+                    'Return JSON: {"publication_date":"YYYY-MM-DD or YYYY-MM or YYYY or null","raw":"verbatim date text or null"}. '
+                    "Prefer the article publication date over modified/updated timestamps when both appear."
+                ),
+            },
+        ],
+    )
+    messages.append(
+        {
+            "role": "assistant",
+            "content": json.dumps(date_payload, ensure_ascii=False),
+        }
+    )
+
+    references_payload = resolver(
+        model=model,
+        messages=[
+            *messages,
+            {
+                "role": "user",
+                "content": (
+                    "List bibliography entries this article cites (works referenced), "
+                    "not navigation, ads, related posts, or same-site links. "
+                    "Return JSON: "
+                    '{"citations":[{"title":"...","authors":["..."],"year":2020,"doi":"10.x/... or null",'
+                    '"url":"https://... or null","raw":"citation line or null",'
+                    '"citing_context":"short note on how this article uses or characterizes the cited work, or null"}]}. '
+                    "Use an empty citations array when none are present."
+                ),
+            },
+        ],
+    )
+
+    authors = _normalize_authors(authors_payload.get("authors"))
+    publication_date, publication_date_raw = _normalize_publication_date(date_payload)
+    citations, citation_warnings = _normalize_citations(references_payload.get("citations"))
+    warnings: List[Dict[str, str]] = list(citation_warnings)
+    if clip.get("truncated"):
+        warnings.append(
+            {
+                "code": "article_truncated",
+                "message": (
+                    f"Article content truncated to {HTML_STRUCTURED_MAX_ARTICLE_CHARS} characters "
+                    "for LLM structured extraction."
+                ),
+            }
+        )
+
+    citations_with_identifiers = sum(
+        1
+        for citation in citations
+        if any(str(citation.get(key) or "").strip() for key in ("doi", "arxiv_id", "isbn", "url"))
+    )
+    structured: Dict[str, Any] = {
+        "authors": authors,
+        "citations": citations,
+        "publication_date": publication_date,
+        "publication_date_raw": publication_date_raw,
+        "summary": {
+            "authors_count": len(authors),
+            "citations_count": len(citations),
+            "citations_with_identifiers": citations_with_identifiers,
+        },
+        "warnings": warnings,
+    }
+    llm_meta = {
+        "model": model,
+        "prompt_version": HTML_STRUCTURED_PROMPT_VERSION,
+        "source_uri": source_uri,
+        "content_kind": content_kind,
+        "article_chars": len(article_content),
+        "article_chars_sent": clip["length"],
+        "turns": 3,
+    }
+    return structured, llm_meta
+
+
+def _initial_article_prompt(
+    *,
+    source_uri: str,
+    page_title: str,
+    reference_title: str,
+    content_kind: str,
+    article_content: str,
+) -> str:
+    return "\n".join(
+        [
+            f"Source URI: {source_uri}",
+            f"Page title: {page_title or '(unknown)'}",
+            f"Reference title hint: {reference_title or '(none)'}",
+            f"Content kind: {content_kind}",
+            "",
+            "Article content:",
+            article_content,
+        ]
+    )
+
+
+def _clip_article(article_content: str) -> Dict[str, Any]:
+    text = str(article_content or "").replace("\x00", "")
+    if len(text) <= HTML_STRUCTURED_MAX_ARTICLE_CHARS:
+        return {"text": text, "length": len(text), "truncated": False}
+    return {
+        "text": text[:HTML_STRUCTURED_MAX_ARTICLE_CHARS],
+        "length": HTML_STRUCTURED_MAX_ARTICLE_CHARS,
+        "truncated": True,
+    }
+
+
+def _normalize_authors(value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    rows: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in value:
+        if isinstance(entry, str):
+            name = _clean_person_name(entry)
+        elif isinstance(entry, dict):
+            name = _clean_person_name(str(entry.get("name") or entry.get("normalized_name") or ""))
+        else:
+            continue
+        if not name:
+            continue
+        key = _normalize_identity(name)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({"name": name, "normalized_name": _normalize_person_name(name)})
+    return rows
+
+
+def _normalize_publication_date(payload: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    raw = str(payload.get("raw") or payload.get("publication_date") or "").strip() or None
+    token = str(payload.get("publication_date") or "").strip()
+    if not token and raw:
+        token = raw
+    if not token:
+        return None, raw
+    normalized = token.replace("/", "-").replace(".", "-").strip()
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", normalized):
+        return normalized, raw
+    if re.fullmatch(r"\d{4}-\d{2}", normalized):
+        return f"{normalized}-01", raw
+    year_match = re.fullmatch(r"(\d{4})", normalized)
+    if year_match:
+        return f"{year_match.group(1)}-01-01", raw
+    return None, raw
+
+
+def _normalize_citations(value: Any) -> tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
+    warnings: List[Dict[str, str]] = []
+    if not isinstance(value, list):
+        return [], warnings
+    rows: List[Dict[str, Any]] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            continue
+        title = str(entry.get("title") or "").strip()
+        authors = [
+            _clean_person_name(str(name))
+            for name in (entry.get("authors") or [])
+            if isinstance(entry.get("authors"), list) and _clean_person_name(str(name))
+        ]
+        year = _coerce_year(entry.get("year"))
+        doi = _normalize_doi(entry.get("doi"))
+        url = str(entry.get("url") or "").strip() or None
+        raw = str(entry.get("raw") or "").strip() or None
+        citing_context = str(entry.get("citing_context") or entry.get("citingContext") or "").strip() or None
+        if not title and not raw and not doi and not url:
+            warnings.append(
+                {
+                    "code": "citation_unusable",
+                    "message": f"LLM citation entry {index + 1} has no title, identifier, or raw line.",
+                }
+            )
+            continue
+        rows.append(
+            {
+                "title": title or None,
+                "authors": authors,
+                "year": year,
+                "venue": str(entry.get("venue") or "").strip() or None,
+                "doi": doi,
+                "arxiv_id": _normalize_arxiv_id(entry.get("arxiv_id") or entry.get("arxivId")),
+                "isbn": str(entry.get("isbn") or "").strip() or None,
+                "url": url,
+                "raw": raw,
+                "citing_context": citing_context,
+            }
+        )
+    return rows, warnings
+
+
+def _openai_json_completion(*, model: str, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+    try:
+        import openai
+    except ImportError as import_error:
+        raise ValueError(
+            "LLM HTML structured extraction requires the openai package. "
+            'Install it with pip install "biblicus[openai]".'
+        ) from import_error
+    api_key = LlmClientConfig(provider="openai", model=model).resolve_api_key()
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(model=model, messages=list(messages))
+    text = str(response.choices[0].message.content or "").strip()
+    payload = _parse_json_object(text)
+    if not isinstance(payload, dict):
+        raise ValueError("LLM HTML structured extraction returned a non-object JSON payload")
+    return payload
+
+
+def _parse_json_object(text: str) -> Dict[str, Any]:
+    cleaned = str(text or "").strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?", "", cleaned).strip()
+        cleaned = re.sub(r"```$", "", cleaned).strip()
+    payload: Any = json.loads(cleaned)
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict):
+        raise ValueError("LLM HTML structured extraction must return a JSON object")
+    return payload
+
+
+def _clean_person_name(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _normalize_person_name(value: str) -> str:
+    tokens = [token for token in _clean_person_name(value).split(" ") if token]
+    if not tokens:
+        return ""
+    if len(tokens) == 1:
+        return tokens[0].lower()
+    return f"{tokens[-1].lower()} {' '.join(token.lower() for token in tokens[:-1])}".strip()
+
+
+def _normalize_identity(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", _clean_person_name(value).lower()).strip()
+
+
+def _coerce_year(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value if 1000 <= value <= 3000 else None
+    match = re.search(r"\b(19|20)\d{2}\b", str(value))
+    return int(match.group(0)) if match else None
+
+
+def _normalize_doi(value: Any) -> Optional[str]:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    lowered = token.lower()
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if lowered.startswith(prefix):
+            token = token[len(prefix) :]
+            break
+    token = token.strip().strip(".")
+    return token or None
+
+
+def _normalize_arxiv_id(value: Any) -> Optional[str]:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    lowered = token.lower()
+    for prefix in ("https://arxiv.org/abs/", "http://arxiv.org/abs/", "arxiv:"):
+        if lowered.startswith(prefix):
+            token = token[len(prefix) :]
+            break
+    return token.strip() or None

--- a/src/biblicus/html_structured_pipeline.py
+++ b/src/biblicus/html_structured_pipeline.py
@@ -1,0 +1,179 @@
+"""
+Orchestrate HTML structured metadata extraction: heuristics first, LLM fallback.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, Optional
+
+from .html_heuristics import (
+    extract_html_heuristics,
+    heuristic_document_to_structured,
+    structured_metadata_is_sufficient,
+)
+from .html_structured import (
+    HTML_STRUCTURED_DEFAULT_MODEL,
+    enrich_web_extraction_with_llm_structured,
+    html_llm_structured_enabled,
+)
+
+HTML_HEURISTICS_ENABLE_ENV = "BIBLICUS_HTML_HEURISTICS"
+HTML_STRUCTURED_PIPELINE_VERSION = "html-structured-pipeline-v1"
+
+
+def html_heuristics_enabled() -> bool:
+    """
+    Return whether BeautifulSoup heuristics should run for web HTML.
+
+    :return: True unless explicitly disabled via environment.
+    :rtype: bool
+    """
+    raw = str(os.environ.get(HTML_HEURISTICS_ENABLE_ENV) or "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def enrich_web_extraction_structured(
+    converted: Dict[str, Any],
+    *,
+    source_uri: str,
+    html_content: str = "",
+    reference_title: str = "",
+    model: str = HTML_STRUCTURED_DEFAULT_MODEL,
+    completion_resolver: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """
+    Attach structured metadata using HTML heuristics, then optional LLM fallback.
+
+    :param converted: Markitdown conversion payload.
+    :type converted: dict[str, Any]
+    :param source_uri: Article URL.
+    :type source_uri: str
+    :param html_content: Raw HTML when available.
+    :type html_content: str
+    :param reference_title: Optional reference title hint.
+    :type reference_title: str
+    :param model: OpenAI model for LLM fallback.
+    :type model: str
+    :param completion_resolver: Optional LLM test hook.
+    :type completion_resolver: Callable[..., dict[str, Any]] or None
+    :return: Updated conversion payload.
+    :rtype: dict[str, Any]
+    """
+    html = str(html_content or "").strip()
+    structured: Dict[str, Any] | None = None
+    provenance: Dict[str, Any] = {"pipeline_version": HTML_STRUCTURED_PIPELINE_VERSION}
+
+    if html and html_heuristics_enabled():
+        try:
+            doc = extract_html_heuristics(html, source_uri=source_uri)
+            structured = heuristic_document_to_structured(doc)
+            if doc.title and not converted.get("title"):
+                converted = {**converted, "title": doc.title}
+            provenance["heuristics"] = {
+                "layers": list(doc.layers),
+                "reference_candidates": len(doc.reference_candidates),
+            }
+        except ValueError as exc:
+            warnings = converted.get("html_heuristic_warnings")
+            if not isinstance(warnings, list):
+                warnings = []
+            warnings.append({"code": "html_heuristics_unavailable", "message": str(exc)})
+            converted = {**converted, "html_heuristic_warnings": warnings}
+
+    if structured and structured_metadata_is_sufficient(structured):
+        return {
+            **converted,
+            "method": "html-heuristics",
+            "structured": structured,
+            "html_structured": provenance,
+        }
+
+    if not html_llm_structured_enabled():
+        if structured and (structured.get("authors") or structured.get("citations")):
+            return {
+                **converted,
+                "method": "html-heuristics-partial",
+                "structured": structured,
+                "html_structured": provenance,
+            }
+        return converted
+
+    llm_payload = enrich_web_extraction_with_llm_structured(
+        converted,
+        source_uri=source_uri,
+        html_content=html,
+        reference_title=reference_title,
+        model=model,
+        completion_resolver=completion_resolver,
+    )
+    llm_structured = (
+        llm_payload.get("structured") if isinstance(llm_payload.get("structured"), dict) else None
+    )
+    if isinstance(llm_structured, dict):
+        merged = _merge_structured(structured, llm_structured)
+        provenance["llm"] = llm_payload.get("llm_structured")
+        return {
+            **llm_payload,
+            "method": _resolve_method(structured, llm_structured),
+            "structured": merged,
+            "html_structured": provenance,
+        }
+    if structured:
+        return {
+            **converted,
+            "method": "html-heuristics-partial",
+            "structured": structured,
+            "html_structured": provenance,
+        }
+    return llm_payload
+
+
+def _resolve_method(
+    heuristic: Dict[str, Any] | None,
+    llm: Dict[str, Any],
+) -> str:
+    if isinstance(heuristic, dict) and (heuristic.get("authors") or heuristic.get("citations")):
+        return "html-heuristics+llm-html"
+    return "llm-html"
+
+
+def _merge_structured(
+    heuristic: Dict[str, Any] | None,
+    llm: Dict[str, Any],
+) -> Dict[str, Any]:
+    if not isinstance(heuristic, dict):
+        return dict(llm)
+    merged = dict(llm)
+    if not merged.get("authors") and heuristic.get("authors"):
+        merged["authors"] = heuristic["authors"]
+    if not merged.get("publication_date") and heuristic.get("publication_date"):
+        merged["publication_date"] = heuristic["publication_date"]
+        merged["publication_date_raw"] = heuristic.get("publication_date_raw")
+    if not merged.get("citations") and heuristic.get("citations"):
+        merged["citations"] = heuristic["citations"]
+    heuristic_warnings = heuristic.get("warnings") if isinstance(heuristic.get("warnings"), list) else []
+    llm_warnings = merged.get("warnings") if isinstance(merged.get("warnings"), list) else []
+    merged["warnings"] = [*heuristic_warnings, *llm_warnings]
+    if heuristic.get("raw_metadata"):
+        merged["raw_metadata"] = {
+            "heuristic": heuristic.get("raw_metadata"),
+            "llm_layers": merged.get("layers"),
+        }
+    summary = merged.get("summary") if isinstance(merged.get("summary"), dict) else {}
+    authors = merged.get("authors") if isinstance(merged.get("authors"), list) else []
+    citations = merged.get("citations") if isinstance(merged.get("citations"), list) else []
+    merged["summary"] = {
+        **summary,
+        "authors_count": len(authors),
+        "citations_count": len(citations),
+        "citations_with_identifiers": sum(
+            1
+            for row in citations
+            if isinstance(row, dict)
+            and any(str(row.get(key) or "").strip() for key in ("doi", "arxiv_id", "isbn", "url"))
+        ),
+    }
+    return merged

--- a/src/biblicus/url_text.py
+++ b/src/biblicus/url_text.py
@@ -1,0 +1,1303 @@
+"""
+URL text extraction with source-aware fetch orchestration.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import random
+import re
+import threading
+import time
+import uuid
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional
+
+from .html_structured_pipeline import enrich_web_extraction_structured
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlparse
+from urllib.request import Request, urlopen
+
+URL_TEXT_PROMPT_VERSION = "url-text-v1"
+URL_TEXT_DEFAULT_TIMEOUT_SECONDS = 20.0
+URL_TEXT_DEFAULT_MAX_RETRIES = 2
+URL_TEXT_DEFAULT_BACKOFF_SECONDS = 0.8
+URL_TEXT_GROBID_URL_ENV = "BIBLICUS_GROBID_URL"
+URL_TEXT_GROBID_TIMEOUT_SECONDS = 180.0
+YOUTUBE_TRANSCRIPT_MAX_WAIT_ENV = "BIBLICUS_YOUTUBE_TRANSCRIPT_MAX_WAIT_SECONDS"
+YOUTUBE_TRANSCRIPT_INITIAL_BACKOFF_ENV = "BIBLICUS_YOUTUBE_TRANSCRIPT_INITIAL_BACKOFF_SECONDS"
+YOUTUBE_TRANSCRIPT_MAX_BACKOFF_ENV = "BIBLICUS_YOUTUBE_TRANSCRIPT_MAX_BACKOFF_SECONDS"
+YOUTUBE_TRANSCRIPT_DEFAULT_MAX_WAIT_SECONDS = 3600.0
+YOUTUBE_TRANSCRIPT_DEFAULT_INITIAL_BACKOFF_SECONDS = 30.0
+YOUTUBE_TRANSCRIPT_DEFAULT_MAX_BACKOFF_SECONDS = 300.0
+
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+)
+
+
+class UrlTextExtractionError(RuntimeError):
+    """
+    Structured URL extraction error.
+
+    :ivar code: Stable machine-readable error code.
+    :vartype code: str
+    :ivar message: Human-readable error message.
+    :vartype message: str
+    :ivar details: Optional diagnostic details.
+    :vartype details: dict[str, Any]
+    """
+
+    def __init__(self, *, code: str, message: str, details: Optional[Dict[str, Any]] = None):
+        self.code = str(code)
+        self.message = str(message)
+        self.details = dict(details or {})
+        super().__init__(self.message)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Render this error as a JSON-serializable object.
+
+        :return: Structured error payload.
+        :rtype: dict[str, Any]
+        """
+        payload: Dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.details:
+            payload["details"] = self.details
+        return payload
+
+
+def load_url_text_input_json(path_or_dash: str) -> Dict[str, Any]:
+    """
+    Load URL text extraction input JSON from a file path or standard input.
+
+    :param path_or_dash: JSON path or ``-`` for standard input.
+    :type path_or_dash: str
+    :return: Parsed JSON object.
+    :rtype: dict[str, Any]
+    :raises ValueError: If JSON is invalid or not an object.
+    """
+    source = str(path_or_dash or "").strip() or "-"
+    if source == "-":
+        import sys
+
+        raw_text = sys.stdin.read()
+    else:
+        with open(source, "r", encoding="utf-8") as handle:
+            raw_text = handle.read()
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid input JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Input JSON must be an object")
+    return payload
+
+
+def extract_url_text(
+    *,
+    source_uri: str,
+    reference_title: str = "",
+    timeout_seconds: float = URL_TEXT_DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = URL_TEXT_DEFAULT_MAX_RETRIES,
+    backoff_seconds: float = URL_TEXT_DEFAULT_BACKOFF_SECONDS,
+) -> Dict[str, Any]:
+    """
+    Extract text from a source URL using source-aware fetch strategy.
+
+    :param source_uri: Source URL.
+    :type source_uri: str
+    :param reference_title: Optional reference title context.
+    :type reference_title: str
+    :param timeout_seconds: Per-attempt timeout in seconds.
+    :type timeout_seconds: float
+    :param max_retries: Maximum retries for transient fetch failures.
+    :type max_retries: int
+    :param backoff_seconds: Base backoff delay in seconds.
+    :type backoff_seconds: float
+    :return: Structured extraction payload.
+    :rtype: dict[str, Any]
+    """
+    uri = str(source_uri or "").strip()
+    if not uri:
+        raise UrlTextExtractionError(code="missing_source_uri", message="source_uri is required")
+
+    source_kind = _classify_source_kind(uri)
+    attempts: List[Dict[str, Any]] = []
+    strategy = {
+        "youtube": "youtube-direct-markitdown",
+        "pdf": "pdf-grobid-only",
+        "web": "markdown-then-html-then-direct",
+    }[source_kind]
+
+    try:
+        if source_kind == "youtube":
+            converted = _attempt_direct_markitdown(uri=uri, source_kind=source_kind, attempts=attempts)
+        elif source_kind == "pdf":
+            converted = _extract_pdf_first(
+                uri=uri,
+                source_kind=source_kind,
+                attempts=attempts,
+                timeout_seconds=timeout_seconds,
+                max_retries=max_retries,
+                backoff_seconds=backoff_seconds,
+            )
+        else:
+            converted = _extract_web(
+                uri=uri,
+                source_kind=source_kind,
+                attempts=attempts,
+                timeout_seconds=timeout_seconds,
+                max_retries=max_retries,
+                backoff_seconds=backoff_seconds,
+            )
+    except UrlTextExtractionError as exc:
+        return {
+            "status": "failed",
+            "source_kind": source_kind,
+            "strategy": strategy,
+            "text": "",
+            "markdown": "",
+            "title": None,
+            "content_type": None,
+            "prompt_version": URL_TEXT_PROMPT_VERSION,
+            "attempts": attempts,
+            "error": exc.to_dict(),
+        }
+
+    text = str(converted.get("text") or "").strip()
+    if not text:
+        return {
+            "status": "failed",
+            "source_kind": source_kind,
+            "strategy": strategy,
+            "text": "",
+            "markdown": "",
+            "title": None,
+            "content_type": str(converted.get("content_type") or "") or None,
+            "prompt_version": URL_TEXT_PROMPT_VERSION,
+            "attempts": attempts,
+            "error": {
+                "code": "empty_text",
+                "message": "URL extraction completed but produced empty text.",
+            },
+        }
+
+    markdown = str(converted.get("markdown") or text)
+    title = str(converted.get("title") or "").strip() or None
+    content_type = str(converted.get("content_type") or "").strip() or None
+    if source_kind == "web" and not isinstance(converted.get("structured"), dict):
+        converted = enrich_web_extraction_structured(
+            converted,
+            source_uri=uri,
+            html_content=str(converted.get("html_content") or ""),
+            reference_title=str(reference_title or ""),
+        )
+        text = str(converted.get("text") or text).strip()
+        markdown = str(converted.get("markdown") or markdown)
+        title = str(converted.get("title") or title or "").strip() or title
+    return {
+        "status": "ok",
+        "source_kind": source_kind,
+        "strategy": strategy,
+        "text": text,
+        "markdown": markdown,
+        "title": title,
+        "content_type": content_type,
+        "method": str(converted.get("method") or "") or None,
+        "grobid": converted.get("grobid") if isinstance(converted.get("grobid"), dict) else None,
+        "structured": converted.get("structured") if isinstance(converted.get("structured"), dict) else None,
+        "prompt_version": URL_TEXT_PROMPT_VERSION,
+        "attempts": attempts,
+        "error": None,
+    }
+
+
+def _extract_pdf_first(
+    *,
+    uri: str,
+    source_kind: str,
+    attempts: List[Dict[str, Any]],
+    timeout_seconds: float,
+    max_retries: int,
+    backoff_seconds: float,
+) -> Dict[str, Any]:
+    fetch_result = _fetch_url_bytes(
+        uri=uri,
+        source_kind=source_kind,
+        step="pdf_fetch",
+        accept="application/pdf, application/octet-stream;q=0.9, */*;q=0.1",
+        timeout_seconds=timeout_seconds,
+        max_retries=max_retries,
+        backoff_seconds=backoff_seconds,
+    )
+    attempts.extend(fetch_result["attempts"])
+    if not fetch_result["ok"]:
+        raise UrlTextExtractionError(
+            code="pdf_fetch_failed",
+            message=f"Could not fetch PDF content from {uri}",
+            details={"source_uri": uri, "fetch_error": fetch_result.get("error")},
+        )
+    try:
+        converted = _convert_pdf_with_grobid(
+            data=fetch_result["body"],
+            source_uri=fetch_result["final_url"] or uri,
+            content_type=fetch_result["content_type"],
+        )
+    except Exception as exc:  # pragma: no cover - endpoint/runtime dependent
+        attempts.append(
+            {
+                "step": "pdf_convert_grobid",
+                "result": "failed",
+                "error": str(exc),
+            }
+        )
+        raise
+    attempts.append(
+        {
+            "step": "pdf_convert_grobid",
+            "result": "ok",
+            "content_type": fetch_result["content_type"],
+            "text_length": len(str(converted.get("text") or "")),
+        }
+    )
+    if not str(converted.get("text") or "").strip():
+        raise UrlTextExtractionError(
+            code="grobid_empty_text",
+            message="GROBID PDF conversion produced empty text.",
+            details={"source_uri": uri},
+        )
+    return converted
+
+
+def _extract_web(
+    *,
+    uri: str,
+    source_kind: str,
+    attempts: List[Dict[str, Any]],
+    timeout_seconds: float,
+    max_retries: int,
+    backoff_seconds: float,
+) -> Dict[str, Any]:
+    html_content = ""
+    for step, accept in (
+        ("web_markdown_fetch", "text/markdown, text/html;q=0.9, text/plain;q=0.8, */*;q=0.1"),
+        ("web_html_fetch", "text/html, application/xhtml+xml;q=0.9, */*;q=0.8"),
+    ):
+        fetch_result = _fetch_url_bytes(
+            uri=uri,
+            source_kind=source_kind,
+            step=step,
+            accept=accept,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+            backoff_seconds=backoff_seconds,
+        )
+        attempts.extend(fetch_result["attempts"])
+        if not fetch_result["ok"]:
+            continue
+        step_html = _html_body_from_fetch(fetch_result)
+        if step_html:
+            html_content = step_html
+        try:
+            converted = _convert_bytes_with_markitdown(
+                data=fetch_result["body"],
+                source_uri=fetch_result["final_url"] or uri,
+                content_type=fetch_result["content_type"],
+            )
+            if html_content:
+                converted["html_content"] = html_content
+            attempts.append(
+                {
+                    "step": f"{step}_convert",
+                    "result": "ok",
+                    "content_type": fetch_result["content_type"],
+                    "text_length": len(str(converted.get("text") or "")),
+                }
+            )
+            if str(converted.get("text") or "").strip():
+                return converted
+            attempts.append(
+                {
+                    "step": f"{step}_convert",
+                    "result": "failed",
+                    "error": "conversion produced empty text",
+                }
+            )
+        except Exception as exc:  # pragma: no cover - covered by tests through monkeypatch
+            attempts.append(
+                {
+                    "step": f"{step}_convert",
+                    "result": "failed",
+                    "error": str(exc),
+                }
+            )
+
+    return _attempt_direct_markitdown(uri=uri, source_kind=source_kind, attempts=attempts)
+
+
+def _attempt_direct_markitdown(
+    *,
+    uri: str,
+    source_kind: str,
+    attempts: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    try:
+        converted = _convert_direct_with_markitdown(uri)
+        attempts.append(
+            {
+                "step": "direct_markitdown",
+                "source_kind": source_kind,
+                "result": "ok",
+                "text_length": len(str(converted.get("text") or "")),
+            }
+        )
+        youtube_retry = converted.get("youtube_transcript_retry")
+        if isinstance(youtube_retry, dict):
+            for entry in youtube_retry.get("attempts") or []:
+                if isinstance(entry, dict):
+                    attempts.append(entry)
+        if str(converted.get("text") or "").strip():
+            return converted
+        raise UrlTextExtractionError(
+            code="direct_conversion_empty",
+            message="Direct MarkItDown conversion produced empty text.",
+        )
+    except UrlTextExtractionError:
+        raise
+    except Exception as exc:
+        attempts.append(
+            {
+                "step": "direct_markitdown",
+                "source_kind": source_kind,
+                "result": "failed",
+                "error": str(exc),
+            }
+        )
+        raise UrlTextExtractionError(
+            code="direct_conversion_failed",
+            message="Direct MarkItDown conversion failed.",
+            details={"source_uri": uri, "error": str(exc)},
+        ) from exc
+
+
+def _fetch_url_bytes(
+    *,
+    uri: str,
+    source_kind: str,
+    step: str,
+    accept: str,
+    timeout_seconds: float,
+    max_retries: int,
+    backoff_seconds: float,
+) -> Dict[str, Any]:
+    attempts: List[Dict[str, Any]] = []
+    retries = max(0, int(max_retries))
+    timeout = max(float(timeout_seconds), 1.0)
+    base_backoff = max(float(backoff_seconds), 0.0)
+
+    for attempt_index in range(retries + 1):
+        request = Request(
+            uri,
+            headers={
+                "User-Agent": _BROWSER_USER_AGENT,
+                "Accept": accept,
+                "Accept-Language": "en-US,en;q=0.9",
+            },
+        )
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                body = response.read()
+                content_type = _normalize_content_type(response.headers.get("Content-Type"))
+                status = int(getattr(response, "status", response.getcode()))
+                final_url = str(getattr(response, "url", "") or uri)
+                attempts.append(
+                    {
+                        "step": step,
+                        "source_kind": source_kind,
+                        "attempt": attempt_index + 1,
+                        "result": "ok",
+                        "accept": accept,
+                        "http_status": status,
+                        "content_type": content_type,
+                        "final_url": final_url,
+                    }
+                )
+                return {
+                    "ok": True,
+                    "body": body,
+                    "content_type": content_type,
+                    "final_url": final_url,
+                    "attempts": attempts,
+                    "error": None,
+                }
+        except HTTPError as exc:
+            attempts.append(
+                {
+                    "step": step,
+                    "source_kind": source_kind,
+                    "attempt": attempt_index + 1,
+                    "result": "failed",
+                    "accept": accept,
+                    "http_status": int(exc.code),
+                    "error": str(exc),
+                }
+            )
+            if not _is_retryable_http_status(int(exc.code)) or attempt_index >= retries:
+                break
+        except URLError as exc:
+            attempts.append(
+                {
+                    "step": step,
+                    "source_kind": source_kind,
+                    "attempt": attempt_index + 1,
+                    "result": "failed",
+                    "accept": accept,
+                    "error": str(exc),
+                }
+            )
+            if attempt_index >= retries:
+                break
+        if base_backoff > 0:
+            time.sleep(base_backoff * (2 ** attempt_index))
+
+    return {
+        "ok": False,
+        "body": b"",
+        "content_type": None,
+        "final_url": uri,
+        "attempts": attempts,
+        "error": {
+            "code": "manual_fetch_failed",
+            "message": f"Manual fetch failed for {uri}",
+        },
+    }
+
+
+def _convert_bytes_with_markitdown(
+    *,
+    data: bytes,
+    source_uri: str,
+    content_type: Optional[str],
+    file_extension: Optional[str] = None,
+) -> Dict[str, Any]:
+    converter = _build_markitdown_converter()
+    extension = file_extension or _infer_file_extension(source_uri=source_uri, content_type=content_type)
+    result = converter.convert(io.BytesIO(data), file_extension=extension, url=source_uri)
+    payload = _markitdown_payload(result)
+    payload["content_type"] = content_type
+    return payload
+
+
+def _convert_direct_with_markitdown(source_uri: str) -> Dict[str, Any]:
+    if _classify_source_kind(source_uri) == "youtube":
+        return _convert_youtube_markdown(source_uri)
+    converter = _build_markitdown_converter()
+    result = converter.convert(source_uri)
+    payload = _markitdown_payload(result)
+    payload["content_type"] = None
+    return payload
+
+
+def _canonicalize_youtube_watch_url(source_uri: str) -> str:
+    parsed = urlparse(str(source_uri or "").strip())
+    host = (parsed.netloc or "").lower()
+    video_id = _youtube_video_id_from_uri(source_uri)
+    if video_id:
+        return f"https://www.youtube.com/watch?v={video_id}"
+    if host.endswith("youtube.com") or host == "youtu.be":
+        return str(source_uri or "").strip()
+    return str(source_uri or "").strip()
+
+
+def _youtube_video_id_from_uri(source_uri: str) -> str:
+    parsed = urlparse(str(source_uri or "").strip())
+    host = (parsed.netloc or "").lower()
+    if host == "youtu.be":
+        token = (parsed.path or "").strip("/").split("/")[0]
+        return token.strip()
+    if host.endswith("youtube.com"):
+        query = parse_qs(parsed.query or "")
+        if query.get("v"):
+            return str(query["v"][0]).strip()
+        path = parsed.path or ""
+        if path.startswith("/shorts/"):
+            return path.removeprefix("/shorts/").split("/")[0].strip()
+        if path.startswith("/embed/"):
+            return path.removeprefix("/embed/").split("/")[0].strip()
+    return ""
+
+
+def _is_low_quality_youtube_markdown(text: str) -> bool:
+    normalized = str(text or "").strip()
+    if not normalized:
+        return True
+    if "### Transcript" in normalized:
+        return False
+    if normalized.startswith("# YouTube") and "### Description" in normalized:
+        return False
+    sample = normalized[:500]
+    footer_markers = (
+        "About](https://www.youtube.com/about",
+        "© 20",
+        "NFL Sunday Ticket",
+        "How YouTube works",
+    )
+    return any(marker in sample for marker in footer_markers)
+
+
+def _youtube_transcript_retry_settings() -> Dict[str, float]:
+    return {
+        "max_wait_seconds": _positive_env_float(
+            YOUTUBE_TRANSCRIPT_MAX_WAIT_ENV,
+            YOUTUBE_TRANSCRIPT_DEFAULT_MAX_WAIT_SECONDS,
+        ),
+        "initial_backoff_seconds": _positive_env_float(
+            YOUTUBE_TRANSCRIPT_INITIAL_BACKOFF_ENV,
+            YOUTUBE_TRANSCRIPT_DEFAULT_INITIAL_BACKOFF_SECONDS,
+        ),
+        "max_backoff_seconds": _positive_env_float(
+            YOUTUBE_TRANSCRIPT_MAX_BACKOFF_ENV,
+            YOUTUBE_TRANSCRIPT_DEFAULT_MAX_BACKOFF_SECONDS,
+        ),
+    }
+
+
+def _positive_env_float(env_name: str, default: float) -> float:
+    raw = str(os.environ.get(env_name) or "").strip()
+    if not raw:
+        return default
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _is_retryable_youtube_transcript_error(error: BaseException) -> bool:
+    if isinstance(error, UrlTextExtractionError):
+        code = str(error.code or "").strip().lower()
+        if code in {
+            "youtube_transcript_unavailable",
+            "direct_conversion_empty",
+            "direct_conversion_failed",
+        }:
+            return True
+        details = error.details if isinstance(error.details, dict) else {}
+        nested_error = str(details.get("error") or "").lower()
+        if "429" in nested_error or "too many requests" in nested_error:
+            return True
+        return True
+    message = str(error or "").lower()
+    retry_markers = (
+        "429",
+        "too many requests",
+        "timedtext",
+        "transcript",
+        "youtube",
+        "connection reset",
+        "connection aborted",
+        "temporarily unavailable",
+        "service unavailable",
+        "503",
+        "502",
+        "504",
+        "no element found",
+        "parseerror",
+    )
+    return any(marker in message for marker in retry_markers)
+
+
+def _fetch_youtube_transcript_text(video_id: str, *, languages: Optional[List[str]] = None) -> str:
+    if not video_id:
+        return ""
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+    except ModuleNotFoundError:
+        return ""
+    requested = [str(language).strip() for language in (languages or ["en"]) if str(language).strip()]
+    if not requested:
+        requested = ["en"]
+    try:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=requested)
+        return " ".join(str(part.text) for part in transcript).strip()
+    except Exception as exc:
+        raise UrlTextExtractionError(
+            code="youtube_transcript_unavailable",
+            message="youtube-transcript-api could not fetch captions for this video.",
+            details={"video_id": video_id, "error": str(exc)},
+        ) from exc
+
+
+def _attempt_youtube_transcript_only_once(source_uri: str) -> Dict[str, Any]:
+    watch_uri = _canonicalize_youtube_watch_url(source_uri)
+    video_id = _youtube_video_id_from_uri(watch_uri)
+    if not video_id:
+        raise UrlTextExtractionError(
+            code="youtube_transcript_unavailable",
+            message="Could not resolve a YouTube video id from the source URI.",
+            details={"source_uri": watch_uri},
+        )
+    transcript = _fetch_youtube_transcript_text(video_id)
+    heading = f"YouTube video {video_id}"
+    markdown = f"# YouTube\n\n## {heading}\n\n### Transcript\n{transcript}\n"
+    return {
+        "text": markdown,
+        "markdown": markdown,
+        "title": heading,
+        "content_type": None,
+        "method": "youtube-transcript-api",
+    }
+
+
+def _attempt_youtube_markdown_once(source_uri: str, *, prefer_transcript_api: bool = False) -> Dict[str, Any]:
+    if prefer_transcript_api:
+        return _attempt_youtube_transcript_only_once(source_uri)
+
+    watch_uri = _canonicalize_youtube_watch_url(source_uri)
+    video_id = _youtube_video_id_from_uri(watch_uri)
+    title: Optional[str] = None
+    markdown = ""
+    text = ""
+
+    converter = _build_markitdown_converter()
+    try:
+        result = converter.convert(watch_uri, youtube_transcript_languages=["en"])
+        payload = _markitdown_payload(result)
+        title = payload.get("title")
+        markdown = str(payload.get("markdown") or "")
+        text = str(payload.get("text") or "")
+    except Exception as exc:
+        if _is_retryable_youtube_transcript_error(exc):
+            text = ""
+        else:
+            raise UrlTextExtractionError(
+                code="direct_conversion_failed",
+                message="YouTube MarkItDown conversion failed.",
+                details={"source_uri": watch_uri, "video_id": video_id or None, "error": str(exc)},
+            ) from exc
+
+    if _is_low_quality_youtube_markdown(text):
+        transcript = _fetch_youtube_transcript_text(video_id) if video_id else ""
+        if transcript:
+            heading = title or f"YouTube video {video_id}"
+            markdown = f"# YouTube\n\n## {heading}\n\n### Transcript\n{transcript}\n"
+            text = markdown
+        else:
+            raise UrlTextExtractionError(
+                code="youtube_transcript_unavailable",
+                message="YouTube transcript could not be retrieved via MarkItDown or youtube-transcript-api.",
+                details={"source_uri": watch_uri, "video_id": video_id or None},
+            )
+    elif video_id and "### Transcript" not in text:
+        transcript = _fetch_youtube_transcript_text(video_id)
+        if transcript:
+            text = f"{text.rstrip()}\n\n### Transcript\n{transcript}\n"
+            markdown = text
+
+    if not str(text or "").strip():
+        raise UrlTextExtractionError(
+            code="direct_conversion_empty",
+            message="YouTube MarkItDown conversion produced empty text.",
+            details={"source_uri": watch_uri, "video_id": video_id or None},
+        )
+
+    return {
+        "text": text,
+        "markdown": markdown or text,
+        "title": title,
+        "content_type": None,
+    }
+
+
+def _convert_youtube_markdown(source_uri: str) -> Dict[str, Any]:
+    settings = _youtube_transcript_retry_settings()
+    deadline = time.monotonic() + settings["max_wait_seconds"]
+    backoff = settings["initial_backoff_seconds"]
+    retry_attempts: List[Dict[str, Any]] = []
+    last_error: Optional[UrlTextExtractionError] = None
+    started_at = time.monotonic()
+
+    while True:
+        attempt_number = len(retry_attempts) + 1
+        attempt_started = time.monotonic()
+        prefer_transcript_api = attempt_number > 1
+        try:
+            payload = _attempt_youtube_markdown_once(
+                source_uri,
+                prefer_transcript_api=prefer_transcript_api,
+            )
+            retry_attempts.append(
+                {
+                    "step": "youtube_transcript",
+                    "attempt": attempt_number,
+                    "result": "ok",
+                    "method": payload.get("method") or ("youtube-transcript-api" if prefer_transcript_api else "markitdown"),
+                    "elapsed_seconds": round(time.monotonic() - attempt_started, 3),
+                }
+            )
+            payload["youtube_transcript_retry"] = {
+                "attempt_count": attempt_number,
+                "waited_seconds": round(time.monotonic() - started_at, 3),
+                "max_wait_seconds": settings["max_wait_seconds"],
+                "attempts": retry_attempts,
+            }
+            return payload
+        except UrlTextExtractionError as exc:
+            last_error = exc
+            retry_attempts.append(
+                {
+                    "step": "youtube_transcript",
+                    "attempt": attempt_number,
+                    "result": "failed",
+                    "method": "youtube-transcript-api" if prefer_transcript_api else "markitdown",
+                    "error_code": exc.code,
+                    "error": exc.message,
+                    "elapsed_seconds": round(time.monotonic() - attempt_started, 3),
+                }
+            )
+            if not _is_retryable_youtube_transcript_error(exc):
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            sleep_seconds = min(backoff, remaining, settings["max_backoff_seconds"])
+            sleep_seconds = sleep_seconds * (0.85 + random.random() * 0.3)
+            retry_attempts[-1]["sleep_seconds"] = round(sleep_seconds, 3)
+            time.sleep(sleep_seconds)
+            backoff = min(max(backoff * 2.0, settings["initial_backoff_seconds"]), settings["max_backoff_seconds"])
+
+    if last_error is None:
+        last_error = UrlTextExtractionError(
+            code="youtube_transcript_unavailable",
+            message="YouTube transcript extraction failed without a structured error.",
+            details={"source_uri": source_uri},
+        )
+    details = dict(last_error.details)
+    details["youtube_transcript_retry"] = {
+        "attempt_count": len(retry_attempts),
+        "waited_seconds": round(time.monotonic() - started_at, 3),
+        "max_wait_seconds": settings["max_wait_seconds"],
+        "attempts": retry_attempts,
+    }
+    raise UrlTextExtractionError(
+        code=last_error.code,
+        message=(
+            f"{last_error.message} "
+            f"(exhausted YouTube retry budget after {details['youtube_transcript_retry']['waited_seconds']}s)."
+        ),
+        details=details,
+    ) from last_error
+
+
+def _convert_pdf_with_grobid(
+    *,
+    data: bytes,
+    source_uri: str,
+    content_type: Optional[str],
+) -> Dict[str, Any]:
+    from .grobid_runtime import ensure_grobid_running, resolve_grobid_base_url
+
+    try:
+        base_url = ensure_grobid_running(resolve_grobid_base_url())
+    except RuntimeError as exc:
+        raise UrlTextExtractionError(
+            code="grobid_unreachable",
+            message=str(exc),
+            details={"source_uri": source_uri},
+        ) from exc
+
+    endpoint = f"{base_url}/api/processFulltextDocument"
+    boundary = f"----biblicus{uuid.uuid4().hex}"
+    body = _multipart_form_data(
+        fields={
+            "consolidateHeader": "1",
+            "consolidateCitations": "1",
+            "includeRawCitations": "0",
+            "includeRawAffiliations": "0",
+        },
+        files={
+            "input": ("document.pdf", data, "application/pdf"),
+        },
+        boundary=boundary,
+    )
+    request = Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers={
+            "User-Agent": _BROWSER_USER_AGENT,
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Accept": "application/xml, text/xml;q=0.9, */*;q=0.1",
+        },
+    )
+    from .grobid_client import call_grobid_with_limits
+
+    def _request_once() -> str:
+        try:
+            with urlopen(request, timeout=URL_TEXT_GROBID_TIMEOUT_SECONDS) as response:
+                return response.read().decode("utf-8", errors="replace")
+        except HTTPError as exc:
+            raise UrlTextExtractionError(
+                code="grobid_http_error",
+                message=f"GROBID HTTP error: {exc}",
+                details={"source_uri": source_uri, "http_status": int(exc.code)},
+            ) from exc
+        except UrlTextExtractionError:
+            raise
+        except Exception as exc:
+            raise UrlTextExtractionError(
+                code="grobid_request_failed",
+                message=f"GROBID request failed: {exc}",
+                details={"source_uri": source_uri},
+            ) from exc
+
+    xml_text = call_grobid_with_limits(_request_once)
+
+    text, title, structured = _tei_to_structured_text(xml_text)
+    return {
+        "text": text,
+        "markdown": text,
+        "title": title,
+        "content_type": content_type or _normalize_content_type("application/pdf"),
+        "method": "grobid",
+        "grobid": {
+            "base_url": base_url,
+            "endpoint": endpoint,
+        },
+        "structured": structured,
+    }
+
+
+def _tei_to_structured_text(tei_xml: str) -> tuple[str, Optional[str], Dict[str, Any]]:
+    xml_text = str(tei_xml or "").strip()
+    if not xml_text:
+        return "", None, {
+            "authors": [],
+            "citations": [],
+            "summary": {"authors_count": 0, "citations_count": 0, "citations_with_identifiers": 0},
+            "warnings": [{"code": "empty_tei_xml", "message": "GROBID returned empty TEI XML."}],
+        }
+    try:
+        root = ET.fromstring(xml_text)
+    except Exception as exc:
+        return "", None, {
+            "authors": [],
+            "citations": [],
+            "summary": {"authors_count": 0, "citations_count": 0, "citations_with_identifiers": 0},
+            "warnings": [{"code": "tei_parse_failed", "message": f"Could not parse TEI XML: {exc}"}],
+        }
+
+    ns = {"tei": "http://www.tei-c.org/ns/1.0"}
+    title = _normalize_inline_text(
+        root.findtext(".//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title", default="", namespaces=ns)
+    )
+    abstract = _normalize_inline_text(
+        "".join(root.findtext(".//tei:teiHeader/tei:profileDesc/tei:abstract", default="", namespaces=ns) or "")
+    )
+
+    blocks: List[str] = []
+    if title:
+        blocks.append(f"# {title}")
+    if abstract:
+        blocks.append("## Abstract")
+        blocks.append(abstract)
+
+    body = root.find(".//tei:text/tei:body", ns)
+    if body is not None:
+        for div in body.findall(".//tei:div", ns):
+            head = _normalize_inline_text("".join(div.findtext("tei:head", default="", namespaces=ns) or ""))
+            if head:
+                blocks.append(f"## {head}")
+            paragraphs = div.findall("tei:p", ns)
+            for paragraph in paragraphs:
+                text = _normalize_inline_text("".join(paragraph.itertext()))
+                if text:
+                    blocks.append(text)
+            # If a div has no direct <p>, fall back to inline text as a paragraph.
+            if not paragraphs:
+                text = _normalize_inline_text("".join(div.itertext()))
+                if text and (not head or text.lower() != head.lower()):
+                    blocks.append(text)
+
+    assembled = "\n\n".join(block for block in blocks if block).strip()
+
+    authors, author_warnings = _extract_tei_authors(root, ns)
+    citations, citation_warnings = _extract_tei_citations(root, ns)
+    citations_with_identifiers = sum(
+        1
+        for citation in citations
+        if any(
+            str(citation.get(key) or "").strip()
+            for key in ("doi", "arxiv_id", "isbn")
+        )
+    )
+    structured = {
+        "authors": authors,
+        "citations": citations,
+        "summary": {
+            "authors_count": len(authors),
+            "citations_count": len(citations),
+            "citations_with_identifiers": citations_with_identifiers,
+        },
+        "warnings": [*author_warnings, *citation_warnings],
+    }
+    return assembled, title or None, structured
+
+
+def _extract_tei_authors(root: ET.Element, ns: Dict[str, str]) -> tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
+    author_rows: List[Dict[str, Any]] = []
+    warnings: List[Dict[str, str]] = []
+    nodes = root.findall(".//tei:teiHeader/tei:fileDesc/tei:sourceDesc//tei:analytic/tei:author", ns)
+    if not nodes:
+        nodes = root.findall(".//tei:teiHeader//tei:titleStmt/tei:author", ns)
+    for index, node in enumerate(nodes):
+        pers_name = node.find("tei:persName", ns)
+        raw_name = _normalize_inline_text("".join(pers_name.itertext())) if pers_name is not None else ""
+        if not raw_name:
+            raw_name = _normalize_inline_text("".join(node.itertext()))
+        name = _normalize_person_name(raw_name)
+        if not name:
+            warnings.append(
+                {"code": "author_name_missing", "message": f"Author entry {index + 1} is missing a usable name."}
+            )
+            continue
+        orcid = _normalize_orcid(_first_non_empty(node.findall(".//tei:idno", ns), {"ORCID", "orcid"}))
+        email = _normalize_inline_text("".join(node.findtext(".//tei:email", default="", namespaces=ns) or ""))
+        affiliation = _normalize_inline_text(" ".join(_affiliation_parts(node, ns)))
+        author_rows.append(
+            {
+                "name": name,
+                "normalized_name": _normalize_author_identity_name(name),
+                "orcid": orcid or None,
+                "email": email or None,
+                "affiliation": affiliation or None,
+            }
+        )
+    return _dedupe_author_rows(author_rows), warnings
+
+
+def _extract_tei_citations(root: ET.Element, ns: Dict[str, str]) -> tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
+    warnings: List[Dict[str, str]] = []
+    citations: List[Dict[str, Any]] = []
+    nodes = root.findall(".//tei:listBibl//tei:biblStruct", ns)
+    if not nodes:
+        warnings.append(
+            {"code": "citations_missing", "message": "No TEI bibliography entries were present in the GROBID output."}
+        )
+        return citations, warnings
+    for index, node in enumerate(nodes):
+        analytic = node.find("tei:analytic", ns)
+        monogr = node.find("tei:monogr", ns)
+        title = _normalize_inline_text(
+            "".join(
+                (
+                    (analytic.findtext("tei:title", default="", namespaces=ns) if analytic is not None else "")
+                    or (monogr.findtext("tei:title", default="", namespaces=ns) if monogr is not None else "")
+                )
+                or ""
+            )
+        )
+        year = _extract_citation_year(node, ns)
+        doi = _normalize_doi(_first_non_empty(node.findall(".//tei:idno", ns), {"DOI", "doi"}))
+        arxiv_id = _normalize_arxiv_id(_first_non_empty(node.findall(".//tei:idno", ns), {"arXiv", "arxiv"}))
+        isbn = _normalize_inline_text(_first_non_empty(node.findall(".//tei:idno", ns), {"ISBN", "isbn"}))
+        url = _extract_citation_url(node, ns)
+        venue = _normalize_inline_text(
+            "".join(
+                (
+                    (monogr.findtext("tei:title", default="", namespaces=ns) if monogr is not None else "")
+                    or node.findtext(".//tei:series/tei:title", default="", namespaces=ns)
+                    or ""
+                )
+            )
+        )
+        citation_authors = _extract_citation_author_names(node, ns)
+        raw = _normalize_inline_text(" ".join(node.itertext()))
+        if not title and not raw:
+            warnings.append(
+                {"code": "citation_unusable", "message": f"Citation entry {index + 1} has no usable title or raw content."}
+            )
+            continue
+        citations.append(
+            {
+                "title": title or None,
+                "authors": citation_authors,
+                "year": year,
+                "venue": venue or None,
+                "doi": doi or None,
+                "arxiv_id": arxiv_id or None,
+                "isbn": isbn or None,
+                "url": url or None,
+                "raw": raw or None,
+            }
+        )
+    return citations, warnings
+
+
+def _extract_citation_author_names(node: ET.Element, ns: Dict[str, str]) -> List[str]:
+    names: List[str] = []
+    for author in node.findall(".//tei:author", ns):
+        pers_name = author.find("tei:persName", ns)
+        raw_name = _normalize_inline_text("".join(pers_name.itertext())) if pers_name is not None else ""
+        if not raw_name:
+            raw_name = _normalize_inline_text("".join(author.itertext()))
+        name = _normalize_person_name(raw_name)
+        if name:
+            names.append(name)
+    deduped: List[str] = []
+    seen: set[str] = set()
+    for name in names:
+        key = _normalize_author_identity_name(name)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(name)
+    return deduped
+
+
+def _extract_citation_year(node: ET.Element, ns: Dict[str, str]) -> Optional[int]:
+    values: List[str] = []
+    for date_node in node.findall(".//tei:date", ns):
+        when = _normalize_inline_text(str(date_node.get("when") or ""))
+        if when:
+            values.append(when)
+        text = _normalize_inline_text("".join(date_node.itertext()))
+        if text:
+            values.append(text)
+    for value in values:
+        match = re.search(r"\b(19|20)\d{2}\b", value)
+        if match:
+            return int(match.group(0))
+    return None
+
+
+def _extract_citation_url(node: ET.Element, ns: Dict[str, str]) -> Optional[str]:
+    for ptr in node.findall(".//tei:ptr", ns):
+        target = _normalize_inline_text(str(ptr.get("target") or ""))
+        if target.startswith("http://") or target.startswith("https://"):
+            return target
+    for ref in node.findall(".//tei:ref", ns):
+        target = _normalize_inline_text(str(ref.get("target") or ""))
+        if target.startswith("http://") or target.startswith("https://"):
+            return target
+        text = _normalize_inline_text("".join(ref.itertext()))
+        if text.startswith("http://") or text.startswith("https://"):
+            return text
+    return None
+
+
+def _first_non_empty(nodes: List[ET.Element], preferred_types: set[str]) -> str:
+    preferred: List[str] = []
+    fallback: List[str] = []
+    for node in nodes:
+        value = _normalize_inline_text("".join(node.itertext()))
+        if not value:
+            continue
+        node_type = _normalize_inline_text(str(node.get("type") or ""))
+        if node_type in preferred_types:
+            preferred.append(value)
+        else:
+            fallback.append(value)
+    if preferred:
+        return preferred[0]
+    if fallback:
+        return fallback[0]
+    return ""
+
+
+def _affiliation_parts(author_node: ET.Element, ns: Dict[str, str]) -> List[str]:
+    parts: List[str] = []
+    for aff in author_node.findall(".//tei:affiliation", ns):
+        text = _normalize_inline_text(" ".join(aff.itertext()))
+        if text:
+            parts.append(text)
+    deduped: List[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        key = part.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(part)
+    return deduped
+
+
+def _normalize_person_name(value: str) -> str:
+    text = _normalize_inline_text(value)
+    if not text:
+        return ""
+    text = re.sub(r"^\d+\s*", "", text)
+    text = re.sub(r"\s+", " ", text).strip(" ,;")
+    return text
+
+
+def _normalize_author_identity_name(value: str) -> str:
+    text = _normalize_inline_text(value).lower()
+    text = re.sub(r"[^a-z0-9]+", " ", text).strip()
+    return text
+
+
+def _normalize_orcid(value: str) -> str:
+    text = _normalize_inline_text(value)
+    if not text:
+        return ""
+    match = re.search(r"(\d{4}-\d{4}-\d{4}-\d{3}[\dXx])", text)
+    if match:
+        return match.group(1).upper()
+    return text
+
+
+def _normalize_doi(value: str) -> str:
+    text = _normalize_inline_text(value)
+    if not text:
+        return ""
+    match = re.search(r"(10\.\d{4,9}/[-._;()/:A-Za-z0-9]+)", text)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _normalize_arxiv_id(value: str) -> str:
+    text = _normalize_inline_text(value)
+    if not text:
+        return ""
+    match = re.search(r"(\d{4}\.\d{4,5}(?:v\d+)?)", text, flags=re.IGNORECASE)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _dedupe_author_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    deduped: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        identity = str(row.get("orcid") or row.get("normalized_name") or "").strip().lower()
+        if not identity:
+            continue
+        if identity in seen:
+            continue
+        seen.add(identity)
+        deduped.append(row)
+    return deduped
+
+
+def _multipart_form_data(
+    *,
+    fields: Dict[str, str],
+    files: Dict[str, tuple[str, bytes, str]],
+    boundary: str,
+) -> bytes:
+    chunks: List[bytes] = []
+    boundary_bytes = boundary.encode("utf-8")
+    for key, value in fields.items():
+        chunks.extend(
+            [
+                b"--" + boundary_bytes + b"\r\n",
+                f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode("utf-8"),
+                str(value).encode("utf-8"),
+                b"\r\n",
+            ]
+        )
+    for key, (filename, payload, content_type) in files.items():
+        chunks.extend(
+            [
+                b"--" + boundary_bytes + b"\r\n",
+                (
+                    f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
+                    f"Content-Type: {content_type}\r\n\r\n"
+                ).encode("utf-8"),
+                payload,
+                b"\r\n",
+            ]
+        )
+    chunks.append(b"--" + boundary_bytes + b"--\r\n")
+    return b"".join(chunks)
+
+
+def _normalize_inline_text(value: str) -> str:
+    text = str(value or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _build_markitdown_converter() -> Any:
+    try:
+        from markitdown import MarkItDown
+    except ModuleNotFoundError as exc:
+        raise UrlTextExtractionError(
+            code="missing_markitdown_dependency",
+            message=(
+                "MarkItDown is required for URL text extraction. "
+                "Install it with pip install \"biblicus[markitdown]\"."
+            ),
+        ) from exc
+    return MarkItDown(enable_plugins=True)
+
+
+def _markitdown_payload(result: Any) -> Dict[str, Any]:
+    text = str(getattr(result, "text_content", "") or "")
+    markdown = str(getattr(result, "markdown", "") or text)
+    title = str(getattr(result, "title", "") or "").strip() or None
+    return {"text": text, "markdown": markdown, "title": title}
+
+
+def _classify_source_kind(source_uri: str) -> str:
+    parsed = urlparse(source_uri)
+    host = (parsed.netloc or "").lower()
+    path = (parsed.path or "").lower()
+    if host.endswith("youtube.com") or host.endswith("youtu.be"):
+        return "youtube"
+    if path.endswith(".pdf"):
+        return "pdf"
+    return "web"
+
+
+def _html_body_from_fetch(fetch_result: Dict[str, Any]) -> str:
+    content_type = _normalize_content_type(fetch_result.get("content_type"))
+    if content_type not in {"text/html", "application/xhtml+xml"}:
+        return ""
+    body = fetch_result.get("body")
+    if not isinstance(body, (bytes, bytearray)):
+        return ""
+    for encoding in ("utf-8", "latin-1"):
+        try:
+            return bytes(body).decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return bytes(body).decode("utf-8", errors="replace")
+
+
+def _normalize_content_type(raw_content_type: Optional[str]) -> Optional[str]:
+    text = str(raw_content_type or "").strip().lower()
+    if not text:
+        return None
+    return text.split(";", 1)[0].strip() or None
+
+
+def _infer_file_extension(*, source_uri: str, content_type: Optional[str]) -> str:
+    content = _normalize_content_type(content_type)
+    if content == "application/pdf":
+        return ".pdf"
+    if content in {"text/markdown", "text/x-markdown"}:
+        return ".md"
+    if content in {"text/plain"}:
+        return ".txt"
+    if content in {"text/html", "application/xhtml+xml"}:
+        return ".html"
+
+    path = (urlparse(source_uri).path or "").lower()
+    if path.endswith(".pdf"):
+        return ".pdf"
+    if path.endswith(".md") or path.endswith(".markdown"):
+        return ".md"
+    if path.endswith(".txt"):
+        return ".txt"
+    return ".html"
+
+
+def _is_retryable_http_status(status_code: int) -> bool:
+    return status_code in {408, 425, 429, 500, 502, 503, 504}

--- a/src/biblicus/web_reference_metadata.py
+++ b/src/biblicus/web_reference_metadata.py
@@ -20,6 +20,35 @@ WEB_REFERENCE_METADATA_VERSION = "web-reference-metadata-v1"
 LOCAL_HTML_SOURCE_URI = "https://papyrus.local/imported-html"
 
 
+def extraction_metadata_from_web_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Shape web metadata for corpus extraction snapshots and graph NER dedup.
+
+    :param payload: Output from :func:`extract_web_reference_metadata_from_html`.
+    :type payload: dict[str, Any]
+    :return: Metadata dict for :class:`~biblicus.models.ExtractedText`.
+    :rtype: dict[str, Any]
+    """
+    structured = payload.get("structured") if isinstance(payload.get("structured"), dict) else {}
+    method = str(payload.get("method") or "html-heuristics").strip() or "html-heuristics"
+    metadata: Dict[str, Any] = {
+        "method": method,
+        "structured": structured,
+    }
+    title = str(payload.get("title") or "").strip()
+    if title:
+        metadata["title"] = title
+    authors = payload.get("authors")
+    if isinstance(authors, list) and authors:
+        metadata["authors"] = list(authors)
+    if payload.get("publicationDate"):
+        metadata["publicationDate"] = payload.get("publicationDate")
+    layers = payload.get("layers")
+    if isinstance(layers, list) and layers:
+        metadata["htmlHeuristicLayers"] = list(layers)
+    return metadata
+
+
 def extract_web_reference_metadata_from_html(
     html: str,
     *,

--- a/src/biblicus/web_reference_metadata.py
+++ b/src/biblicus/web_reference_metadata.py
@@ -1,0 +1,281 @@
+"""
+Shared web page metadata extraction for references and entity extraction.
+
+Uses the same BeautifulSoup heuristic stack as URL text / graph intake
+(``html_heuristics`` + optional ``html_structured_pipeline``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .html_heuristics import (
+    HtmlHeuristicDocument,
+    extract_html_heuristics,
+    heuristic_document_to_structured,
+)
+from .html_structured_pipeline import enrich_web_extraction_structured, html_heuristics_enabled
+
+WEB_REFERENCE_METADATA_VERSION = "web-reference-metadata-v1"
+LOCAL_HTML_SOURCE_URI = "https://papyrus.local/imported-html"
+
+
+def extract_web_reference_metadata_from_html(
+    html: str,
+    *,
+    source_uri: str = "",
+    reference_title: str = "",
+    use_llm_fallback: bool = False,
+    model: str = "",
+    completion_resolver: Any = None,
+) -> Dict[str, Any]:
+    """
+    Extract reference-oriented metadata from HTML using layered heuristics.
+
+    :param html: Raw HTML document.
+    :type html: str
+    :param source_uri: Canonical page URL for link resolution and provenance.
+    :type source_uri: str
+    :param reference_title: Optional title hint for LLM fallback.
+    :type reference_title: str
+    :param use_llm_fallback: When True, run LLM structured enrichment if heuristics are sparse.
+    :type use_llm_fallback: bool
+    :param model: OpenAI model id for LLM fallback.
+    :type model: str
+    :param completion_resolver: Optional test hook for LLM fallback.
+    :return: JSON-serializable metadata payload.
+    :rtype: dict[str, Any]
+    """
+    html_body = str(html or "")
+    uri = str(source_uri or "").strip() or LOCAL_HTML_SOURCE_URI
+    if not html_body.strip():
+        return _empty_payload(source_uri=uri, method="empty_html")
+
+    if not html_heuristics_enabled():
+        return _empty_payload(
+            source_uri=uri,
+            method="html_heuristics_disabled",
+            warnings=[{"code": "html_heuristics_disabled", "message": "HTML heuristics are disabled."}],
+        )
+
+    try:
+        doc = extract_html_heuristics(html_body, source_uri=uri)
+    except ValueError as exc:
+        return _empty_payload(
+            source_uri=uri,
+            method="html_heuristics_unavailable",
+            warnings=[{"code": "html_heuristics_unavailable", "message": str(exc)}],
+        )
+
+    structured = heuristic_document_to_structured(doc)
+    method = "html-heuristics"
+    subtitle = _subtitle_from_document(doc)
+
+    if use_llm_fallback:
+        enriched = enrich_web_extraction_structured(
+            {"text": doc.body_text or "", "markdown": doc.body_text or "", "title": doc.title},
+            source_uri=uri,
+            html_content=html_body,
+            reference_title=reference_title,
+            model=model,
+            completion_resolver=completion_resolver,
+        )
+        llm_structured = enriched.get("structured") if isinstance(enriched.get("structured"), dict) else None
+        if isinstance(llm_structured, dict):
+            structured = llm_structured
+            method = str(enriched.get("method") or method)
+        if not doc.title:
+            doc_title = str(enriched.get("title") or "").strip()
+            if doc_title:
+                doc.title = doc_title
+        if not subtitle:
+            subtitle = _subtitle_from_structured(structured)
+
+    return _document_to_payload(doc, structured=structured, method=method, subtitle=subtitle)
+
+
+def extract_web_reference_metadata_from_url(
+    source_uri: str,
+    *,
+    reference_title: str = "",
+    use_llm_fallback: bool = False,
+    model: str = "",
+    completion_resolver: Any = None,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    """
+    Fetch a web page and extract reference metadata.
+
+    :param source_uri: HTTP(S) URL.
+    :type source_uri: str
+    :param reference_title: Optional title hint for LLM fallback.
+    :type reference_title: str
+    :param use_llm_fallback: Whether to run LLM fallback when heuristics are sparse.
+    :type use_llm_fallback: bool
+    :param model: OpenAI model for LLM fallback.
+    :type model: str
+    :param completion_resolver: Optional LLM test hook.
+    :param timeout_seconds: Fetch timeout.
+    :type timeout_seconds: float
+    :return: Metadata payload.
+    :rtype: dict[str, Any]
+    """
+    uri = str(source_uri or "").strip()
+    if not uri.lower().startswith(("http://", "https://")):
+        return _empty_payload(
+            source_uri=uri,
+            method="unsupported_uri",
+            warnings=[{"code": "unsupported_uri", "message": "Web metadata requires an http(s) URL."}],
+        )
+    html, fetch_warnings = _fetch_html(uri, timeout_seconds=timeout_seconds)
+    payload = extract_web_reference_metadata_from_html(
+        html,
+        source_uri=uri,
+        reference_title=reference_title,
+        use_llm_fallback=use_llm_fallback,
+        model=model,
+        completion_resolver=completion_resolver,
+    )
+    warnings = list(payload.get("warnings") or [])
+    warnings.extend(fetch_warnings)
+    payload["warnings"] = warnings
+    return payload
+
+
+def title_subtitle_resolution_from_web_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Map web metadata payload to Papyrus title/subtitle resolution shape.
+
+    :param metadata: Output from :func:`extract_web_reference_metadata_from_html`.
+    :type metadata: dict[str, Any]
+    :return: Title/subtitle fields for reference curation signals.
+    :rtype: dict[str, Any]
+    """
+    title = str(metadata.get("title") or "").strip()
+    subtitle = str(metadata.get("subtitle") or "").strip()
+    if not title:
+        return {}
+    source_uri = str(metadata.get("sourceUri") or "").strip()
+    layers = metadata.get("layers") if isinstance(metadata.get("layers"), list) else []
+    layer_hint = ", ".join(str(layer) for layer in layers[:4]) if layers else "html_heuristics"
+    return {
+        "title": title,
+        "subtitle": subtitle,
+        "titleMode": "original_web_metadata",
+        "subtitleMode": "original_web_metadata" if subtitle else "unresolved",
+        "source": str(metadata.get("method") or "html_heuristics"),
+        "sourceUrls": [source_uri] if source_uri else [],
+        "rationale": f"Resolved from structured HTML metadata ({layer_hint}).",
+    }
+
+
+def _document_to_payload(
+    doc: HtmlHeuristicDocument,
+    *,
+    structured: Dict[str, Any],
+    method: str,
+    subtitle: str,
+) -> Dict[str, Any]:
+    author_names = [str(row.get("name") or "").strip() for row in doc.authors if isinstance(row, dict)]
+    author_names = [name for name in author_names if name]
+    return {
+        "schemaVersion": WEB_REFERENCE_METADATA_VERSION,
+        "sourceUri": doc.source_uri,
+        "title": doc.title,
+        "subtitle": subtitle or None,
+        "authors": author_names,
+        "authorsStructured": list(doc.authors),
+        "publicationDate": doc.publication_date,
+        "publicationDateRaw": doc.publication_date_raw,
+        "updatedAt": doc.updated_at,
+        "structured": structured,
+        "method": method,
+        "layers": list(doc.layers),
+        "rawMetadata": dict(doc.raw_metadata),
+        "warnings": list(doc.warnings),
+        "referenceCandidates": list(doc.reference_candidates),
+        "citationCount": len(structured.get("citations") or []) if isinstance(structured, dict) else 0,
+    }
+
+
+def _subtitle_from_document(doc: HtmlHeuristicDocument) -> str:
+    raw = doc.raw_metadata if isinstance(doc.raw_metadata, dict) else {}
+    open_graph = raw.get("open_graph") if isinstance(raw.get("open_graph"), dict) else {}
+    for key in ("og:description", "description"):
+        value = str(open_graph.get(key) or "").strip()
+        if value and value != str(doc.title or "").strip():
+            return value
+    twitter = raw.get("twitter_card") if isinstance(raw.get("twitter_card"), dict) else {}
+    description = str(twitter.get("twitter:description") or "").strip()
+    if description and description != str(doc.title or "").strip():
+        return description
+    return ""
+
+
+def _subtitle_from_structured(structured: Dict[str, Any]) -> str:
+    if not isinstance(structured, dict):
+        return ""
+    raw = structured.get("raw_metadata") if isinstance(structured.get("raw_metadata"), dict) else {}
+    heuristic = raw.get("heuristic") if isinstance(raw.get("heuristic"), dict) else raw
+    open_graph = heuristic.get("open_graph") if isinstance(heuristic.get("open_graph"), dict) else {}
+    value = str(open_graph.get("og:description") or "").strip()
+    return value
+
+
+def _fetch_html(source_uri: str, *, timeout_seconds: float) -> tuple[str, List[Dict[str, str]]]:
+    from .url_text import URL_TEXT_DEFAULT_MAX_RETRIES, _fetch_url_bytes, _html_body_from_fetch
+
+    warnings: List[Dict[str, str]] = []
+    for step, accept in (
+        ("web_html_fetch", "text/html, application/xhtml+xml;q=0.9, */*;q=0.8"),
+        ("web_markdown_fetch", "text/markdown, text/html;q=0.9, text/plain;q=0.8, */*;q=0.1"),
+    ):
+        fetch_result = _fetch_url_bytes(
+            uri=source_uri,
+            source_kind="web",
+            step=step,
+            accept=accept,
+            timeout_seconds=timeout_seconds,
+            max_retries=URL_TEXT_DEFAULT_MAX_RETRIES,
+            backoff_seconds=0.8,
+        )
+        if not fetch_result.get("ok"):
+            error = fetch_result.get("error") if isinstance(fetch_result.get("error"), dict) else {}
+            warnings.append(
+                {
+                    "code": str(error.get("code") or "fetch_failed"),
+                    "message": str(error.get("message") or f"Fetch failed during {step}."),
+                }
+            )
+            continue
+        html = _html_body_from_fetch(fetch_result)
+        if html.strip():
+            return html, warnings
+        warnings.append({"code": "empty_html_body", "message": f"No HTML body returned during {step}."})
+    return "", warnings
+
+
+def _empty_payload(
+    *,
+    source_uri: str,
+    method: str,
+    warnings: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    return {
+        "schemaVersion": WEB_REFERENCE_METADATA_VERSION,
+        "sourceUri": source_uri,
+        "title": None,
+        "subtitle": None,
+        "authors": [],
+        "authorsStructured": [],
+        "publicationDate": None,
+        "publicationDateRaw": None,
+        "updatedAt": None,
+        "structured": {"authors": [], "citations": [], "warnings": list(warnings or [])},
+        "method": method,
+        "layers": [],
+        "rawMetadata": {},
+        "warnings": list(warnings or []),
+        "referenceCandidates": [],
+        "citationCount": 0,
+    }

--- a/tests/fixtures/html_heuristics/README.md
+++ b/tests/fixtures/html_heuristics/README.md
@@ -1,0 +1,24 @@
+# HTML heuristic extraction fixtures
+
+All HTML files in this directory are **original synthetic documents** written for
+Biblicus tests, or **minimal structural snippets** created for this repository.
+
+## License
+
+The files in this directory are released under the **MIT License** (same as Biblicus).
+You may copy and adapt them freely in other open-source projects.
+
+They intentionally avoid reproducing full text from third-party articles, blogs, or
+paywalled publishers. They model common real-world markup patterns (JSON-LD,
+Open Graph, reference lists, footer links) without embedding copyrighted prose.
+
+## Files
+
+| File | What it exercises |
+|------|-------------------|
+| `synthetic_blog_json_ld.html` | `BlogPosting` JSON-LD, author, date, References list |
+| `synthetic_news_open_graph.html` | Open Graph / `article:*` meta tags |
+| `synthetic_references_only.html` | Bibliography `<h2>References</h2>` + `<ol>` |
+| `synthetic_footer_links.html` | External links in page footer |
+| `synthetic_sparse.html` | Minimal HTML with almost no metadata (LLM/heuristic gap case) |
+| `synthetic_citations_weak.html` | Reference list without years/DOIs (partial heuristic + LLM merge) |

--- a/tests/fixtures/html_heuristics/synthetic_blog_json_ld.html
+++ b/tests/fixtures/html_heuristics/synthetic_blog_json_ld.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Understanding Sequence Models (Biblicus fixture)</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Understanding Sequence Models",
+        "datePublished": "2021-03-15",
+        "dateModified": "2021-03-20",
+        "author": [
+          {"@type": "Person", "name": "Alex Example"},
+          {"@type": "Person", "name": "Blair Sample"}
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <article>
+      <header>
+        <h1>Understanding Sequence Models</h1>
+        <p class="byline">Alex Example and Blair Sample</p>
+      </header>
+      <p>
+        This short fixture article explains how recurrent and attention-based models
+        compare on small sequence tasks. It is not a copy of any external publication.
+      </p>
+      <h2>References</h2>
+      <ol>
+        <li>
+          Jordan Example, Taylor Sample (2015). Recurrent nets for small sequences.
+          https://example.test/papers/recurrent-small-sequences
+        </li>
+        <li>
+          Morgan Demo (2018). Attention for structured inputs. doi:10.5555/1234567.89
+        </li>
+      </ol>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/html_heuristics/synthetic_citations_weak.html
+++ b/tests/fixtures/html_heuristics/synthetic_citations_weak.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Weak Bibliography Fixture</title>
+  </head>
+  <body>
+    <article>
+      <h1>Weak Bibliography Fixture</h1>
+      <p>References without years, authors, or identifiers in the list text.</p>
+      <h2>References</h2>
+      <ol>
+        <li>Alpha Paper Overview</li>
+        <li>Beta Study Notes</li>
+      </ol>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/html_heuristics/synthetic_footer_links.html
+++ b/tests/fixtures/html_heuristics/synthetic_footer_links.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Link Harvest Fixture</title>
+  </head>
+  <body>
+    <article>
+      <h1>Link Harvest Fixture</h1>
+      <p>Main content without a formal references heading.</p>
+      <p>Padding paragraph one.</p>
+      <p>Padding paragraph two.</p>
+      <p>Padding paragraph three.</p>
+      <p>Padding paragraph four.</p>
+    </article>
+    <footer>
+      <p>Further reading</p>
+      <a href="https://example.test/external/paper-a">Paper A overview</a>
+      <a href="https://example.test/external/paper-b">Paper B notes</a>
+      <a href="/internal/local-page">Local page</a>
+    </footer>
+  </body>
+</html>

--- a/tests/fixtures/html_heuristics/synthetic_news_open_graph.html
+++ b/tests/fixtures/html_heuristics/synthetic_news_open_graph.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Corpus Audit Checklist" />
+    <meta property="article:published_time" content="2024-11-02T09:30:00Z" />
+    <meta property="article:modified_time" content="2024-11-03T14:00:00Z" />
+    <meta property="article:author" content="Casey Reviewer" />
+    <meta name="twitter:creator" content="@casey_fixture" />
+    <title>Corpus Audit Checklist</title>
+  </head>
+  <body>
+    <main>
+      <h1>Corpus Audit Checklist</h1>
+      <p>Fixture news-style page for Open Graph and Twitter card heuristics.</p>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/html_heuristics/synthetic_references_only.html
+++ b/tests/fixtures/html_heuristics/synthetic_references_only.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="author" content="Dana Writer" />
+    <title>Evaluation Notes (fixture)</title>
+  </head>
+  <body>
+    <article>
+      <h1>Evaluation Notes</h1>
+      <p>Fixture article with only HTML meta author and a bibliography section.</p>
+      <h2>Bibliography</h2>
+      <ul>
+        <li>Riley Test (2019). Baselines for retrieval benchmarks.</li>
+        <li>Sam Proof, Jo Bench (2020). Measuring citation graphs in small corpora.</li>
+      </ul>
+    </article>
+  </body>
+</html>

--- a/tests/fixtures/html_heuristics/synthetic_sparse.html
+++ b/tests/fixtures/html_heuristics/synthetic_sparse.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sparse Fixture</title>
+  </head>
+  <body>
+    <div>
+      <h1>Sparse Fixture</h1>
+      <p>No JSON-LD, Open Graph, author meta, or references section.</p>
+    </div>
+  </body>
+</html>

--- a/tests/test_extract_url_text.py
+++ b/tests/test_extract_url_text.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import json
+
+from biblicus import cli
+from biblicus import url_text as url_text_module
+
+
+def test_extract_url_text_web_markdown_first_success(monkeypatch):
+    call_steps = []
+
+    def fake_fetch_url_bytes(**kwargs):
+        call_steps.append(kwargs["step"])
+        return {
+            "ok": True,
+            "body": b"# markdown body",
+            "content_type": "text/markdown",
+            "final_url": kwargs["uri"],
+            "attempts": [{"step": kwargs["step"], "result": "ok"}],
+            "error": None,
+        }
+
+    monkeypatch.setattr(url_text_module, "_fetch_url_bytes", fake_fetch_url_bytes)
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_bytes_with_markitdown",
+        lambda **kwargs: {
+            "text": "Extracted markdown text",
+            "markdown": "# Extracted markdown text",
+            "title": "Markdown title",
+            "content_type": kwargs.get("content_type"),
+        },
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("direct should not run")),
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://example.test/article")
+
+    assert result["status"] == "ok"
+    assert result["source_kind"] == "web"
+    assert result["text"] == "Extracted markdown text"
+    assert call_steps == ["web_markdown_fetch"]
+
+
+def test_extract_url_text_web_falls_back_to_html(monkeypatch):
+    call_steps = []
+
+    def fake_fetch_url_bytes(**kwargs):
+        call_steps.append(kwargs["step"])
+        if kwargs["step"] == "web_markdown_fetch":
+            return {
+                "ok": False,
+                "body": b"",
+                "content_type": None,
+                "final_url": kwargs["uri"],
+                "attempts": [{"step": kwargs["step"], "result": "failed"}],
+                "error": {"code": "manual_fetch_failed", "message": "no markdown"},
+            }
+        return {
+            "ok": True,
+            "body": b"<html><body>html fallback</body></html>",
+            "content_type": "text/html",
+            "final_url": kwargs["uri"],
+            "attempts": [{"step": kwargs["step"], "result": "ok"}],
+            "error": None,
+        }
+
+    monkeypatch.setattr(url_text_module, "_fetch_url_bytes", fake_fetch_url_bytes)
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_bytes_with_markitdown",
+        lambda **kwargs: {
+            "text": "Extracted from html",
+            "markdown": "Extracted from html",
+            "title": None,
+            "content_type": kwargs.get("content_type"),
+        },
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("direct should not run")),
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://example.test/article")
+
+    assert result["status"] == "ok"
+    assert result["text"] == "Extracted from html"
+    assert call_steps == ["web_markdown_fetch", "web_html_fetch"]
+
+
+def test_extract_url_text_pdf_uses_grobid_only(monkeypatch):
+    call_steps = []
+
+    def fake_fetch_url_bytes(**kwargs):
+        call_steps.append(kwargs["step"])
+        return {
+            "ok": True,
+            "body": b"%PDF-fake",
+            "content_type": "application/pdf",
+            "final_url": kwargs["uri"],
+            "attempts": [{"step": kwargs["step"], "result": "ok"}],
+            "error": None,
+        }
+
+    monkeypatch.setattr(url_text_module, "_fetch_url_bytes", fake_fetch_url_bytes)
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_pdf_with_grobid",
+        lambda **kwargs: {
+            "text": "Extracted PDF text",
+            "markdown": "Extracted PDF text",
+            "title": "PDF title",
+            "content_type": kwargs.get("content_type"),
+            "structured": {
+                "authors": [{"name": "Ada Lovelace", "normalized_name": "ada lovelace"}],
+                "citations": [{"title": "Prior work"}],
+                "summary": {"authors_count": 1, "citations_count": 1, "citations_with_identifiers": 0},
+                "warnings": [],
+            },
+        },
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("direct should not run")),
+    )
+    result = url_text_module.extract_url_text(source_uri="https://example.test/report.pdf")
+
+    assert result["status"] == "ok"
+    assert result["source_kind"] == "pdf"
+    assert result["text"] == "Extracted PDF text"
+    assert result["structured"]["summary"]["citations_count"] == 1
+    assert call_steps == ["pdf_fetch"]
+
+
+def test_extract_url_text_pdf_returns_structured_error_when_grobid_fails(monkeypatch):
+    monkeypatch.setattr(
+        url_text_module,
+        "_fetch_url_bytes",
+        lambda **kwargs: {
+            "ok": True,
+            "body": b"%PDF-fake",
+            "content_type": "application/pdf",
+            "final_url": kwargs["uri"],
+            "attempts": [{"step": kwargs["step"], "result": "ok"}],
+            "error": None,
+        },
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_pdf_with_grobid",
+        lambda **_kwargs: (_ for _ in ()).throw(url_text_module.UrlTextExtractionError(code="grobid_unreachable", message="down")),
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://example.test/report.pdf")
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "grobid_unreachable"
+
+
+def test_tei_to_structured_text_extracts_authors_and_citations():
+    tei = """
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+        <fileDesc>
+          <titleStmt><title>Example Paper</title></titleStmt>
+          <sourceDesc>
+            <biblStruct>
+              <analytic>
+                <author>
+                  <persName><forename>Ada</forename><surname>Lovelace</surname></persName>
+                  <idno type="ORCID">0000-0001-2345-6789</idno>
+                  <email>ada@example.org</email>
+                </author>
+              </analytic>
+            </biblStruct>
+          </sourceDesc>
+        </fileDesc>
+      </teiHeader>
+      <text>
+        <body>
+          <div><head>Introduction</head><p>Hello world.</p></div>
+        </body>
+        <back>
+          <listBibl>
+            <biblStruct>
+              <analytic>
+                <title>Prior Citation</title>
+                <author><persName><forename>Alan</forename><surname>Turing</surname></persName></author>
+              </analytic>
+              <monogr>
+                <title>Journal X</title>
+                <imprint><date when="2024"/></imprint>
+              </monogr>
+              <idno type="DOI">10.1000/xyz123</idno>
+            </biblStruct>
+          </listBibl>
+        </back>
+      </text>
+    </TEI>
+    """
+    text, title, structured = url_text_module._tei_to_structured_text(tei)
+    assert title == "Example Paper"
+    assert "Hello world." in text
+    assert structured["summary"]["authors_count"] == 1
+    assert structured["summary"]["citations_count"] == 1
+    assert structured["authors"][0]["orcid"] == "0000-0001-2345-6789"
+    assert structured["citations"][0]["doi"] == "10.1000/xyz123"
+
+
+def test_tei_to_structured_text_handles_malformed_xml_with_bounded_warning():
+    text, title, structured = url_text_module._tei_to_structured_text("<TEI><broken")
+    assert text == ""
+    assert title is None
+    assert isinstance(structured["warnings"], list)
+    assert structured["warnings"][0]["code"] == "tei_parse_failed"
+
+
+def test_canonicalize_youtube_watch_url_supports_short_links():
+    assert (
+        url_text_module._canonicalize_youtube_watch_url("https://youtu.be/jGwO_UgTS7I")
+        == "https://www.youtube.com/watch?v=jGwO_UgTS7I"
+    )
+
+
+def test_canonicalize_youtube_watch_url_strips_timestamp_query():
+    assert (
+        url_text_module._canonicalize_youtube_watch_url(
+            "https://www.youtube.com/watch?v=wE1ZgJdt4uM&t=1935s"
+        )
+        == "https://www.youtube.com/watch?v=wE1ZgJdt4uM"
+    )
+
+
+def test_convert_youtube_markdown_falls_back_to_transcript_api(monkeypatch):
+    monkeypatch.setattr(
+        url_text_module,
+        "_attempt_youtube_markdown_once",
+        lambda _uri, **_kwargs: {
+            "text": "# YouTube\n\n## Title\n\n### Transcript\nfallback transcript text\n",
+            "markdown": "# YouTube\n\n## Title\n\n### Transcript\nfallback transcript text\n",
+            "title": "Title",
+            "content_type": None,
+        },
+    )
+
+    payload = url_text_module._convert_youtube_markdown("https://youtu.be/abc123")
+
+    assert "fallback transcript text" in payload["text"]
+    assert "### Transcript" in payload["markdown"]
+
+
+def test_convert_youtube_markdown_retries_with_backoff(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_once(_uri: str, **_kwargs):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise url_text_module.UrlTextExtractionError(
+                code="youtube_transcript_unavailable",
+                message="429 Too Many Requests",
+                details={"error": "429"},
+            )
+        return {
+            "text": "# YouTube\n\n## Title\n\n### Transcript\nhello after retry\n",
+            "markdown": "# YouTube\n\n## Title\n\n### Transcript\nhello after retry\n",
+            "title": "Title",
+            "content_type": None,
+        }
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(url_text_module, "_attempt_youtube_markdown_once", fake_once)
+    monkeypatch.setattr(
+        url_text_module,
+        "_youtube_transcript_retry_settings",
+        lambda: {
+            "max_wait_seconds": 300.0,
+            "initial_backoff_seconds": 0.01,
+            "max_backoff_seconds": 0.05,
+        },
+    )
+    monkeypatch.setattr(url_text_module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    payload = url_text_module._convert_youtube_markdown("https://www.youtube.com/watch?v=abc123")
+
+    assert calls["count"] == 3
+    assert len(sleeps) == 2
+    assert "hello after retry" in payload["text"]
+    assert payload["youtube_transcript_retry"]["attempt_count"] == 3
+
+
+def test_extract_url_text_youtube_uses_direct_only(monkeypatch):
+    monkeypatch.setattr(
+        url_text_module,
+        "_fetch_url_bytes",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("manual fetch should not run for youtube")),
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: {
+            "text": "YouTube transcript",
+            "markdown": "YouTube transcript",
+            "title": "Video title",
+            "content_type": None,
+        },
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://www.youtube.com/watch?v=abc")
+
+    assert result["status"] == "ok"
+    assert result["source_kind"] == "youtube"
+    assert result["text"] == "YouTube transcript"
+
+
+def test_extract_url_text_returns_structured_error_when_all_paths_fail(monkeypatch):
+    def fake_fetch_url_bytes(**kwargs):
+        return {
+            "ok": False,
+            "body": b"",
+            "content_type": None,
+            "final_url": kwargs["uri"],
+            "attempts": [{"step": kwargs["step"], "result": "failed"}],
+            "error": {"code": "manual_fetch_failed", "message": "blocked"},
+        }
+
+    monkeypatch.setattr(url_text_module, "_fetch_url_bytes", fake_fetch_url_bytes)
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("direct blocked")),
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://example.test/article")
+
+    assert result["status"] == "failed"
+    assert result["error"]["code"] == "direct_conversion_failed"
+    assert isinstance(result["attempts"], list)
+    assert result["attempts"]
+
+
+def test_cli_extract_url_text_outputs_json_contract(tmp_path, monkeypatch, capsys):
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"source_uri": "https://example.test/article"}), encoding="utf-8")
+
+    captured = {}
+
+    def fake_extract_url_text(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "ok",
+            "source_kind": "web",
+            "strategy": "markdown-then-html-then-direct",
+            "text": "Extracted text",
+            "markdown": "Extracted text",
+            "title": "Example",
+            "content_type": "text/html",
+            "prompt_version": "url-text-v1",
+            "attempts": [{"step": "web_markdown_fetch", "result": "ok"}],
+            "error": None,
+        }
+
+    monkeypatch.setattr(url_text_module, "extract_url_text", fake_extract_url_text)
+
+    exit_code = cli.main([
+        "extract",
+        "url-text",
+        "--input-json",
+        str(input_path),
+        "--format",
+        "json",
+    ])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    assert captured["source_uri"] == "https://example.test/article"
+
+
+def test_cli_extract_url_text_rejects_missing_source_uri(tmp_path, capsys):
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps({"reference_title": "Missing URI"}), encoding="utf-8")
+
+    exit_code = cli.main([
+        "extract",
+        "url-text",
+        "--input-json",
+        str(input_path),
+        "--format",
+        "json",
+    ])
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "failed"
+    assert payload["error"]["code"] == "missing_source_uri"
+
+
+def test_cli_extract_url_text_rejects_malformed_json(tmp_path, capsys):
+    input_path = tmp_path / "bad.json"
+    input_path.write_text("{not-json", encoding="utf-8")
+
+    exit_code = cli.main([
+        "extract",
+        "url-text",
+        "--input-json",
+        str(input_path),
+        "--format",
+        "json",
+    ])
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "failed"
+    assert payload["error"]["code"] == "invalid_input_json"

--- a/tests/test_grobid_client.py
+++ b/tests/test_grobid_client.py
@@ -1,0 +1,46 @@
+"""Tests for GROBID concurrency and retry helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from biblicus.grobid_client import call_grobid_with_limits, is_retryable_grobid_error
+from biblicus.url_text import UrlTextExtractionError
+
+
+def test_is_retryable_grobid_error_for_transient_codes():
+    assert is_retryable_grobid_error(
+        UrlTextExtractionError(code="grobid_request_failed", message="timeout")
+    )
+    assert is_retryable_grobid_error(
+        UrlTextExtractionError(
+            code="grobid_http_error",
+            message="busy",
+            details={"http_status": 503},
+        )
+    )
+    assert not is_retryable_grobid_error(
+        UrlTextExtractionError(
+            code="grobid_http_error",
+            message="bad request",
+            details={"http_status": 400},
+        )
+    )
+
+
+def test_call_grobid_with_limits_retries(monkeypatch):
+    attempts = {"count": 0}
+
+    def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise UrlTextExtractionError(code="grobid_request_failed", message="temporary")
+        return "ok"
+
+    monkeypatch.setenv("BIBLICUS_GROBID_MAX_RETRIES", "3")
+    monkeypatch.setenv("BIBLICUS_GROBID_MAX_CONCURRENT", "1")
+    import biblicus.grobid_client as grobid_client
+
+    grobid_client._GROBID_SEMAPHORE = None
+    assert call_grobid_with_limits(flaky) == "ok"
+    assert attempts["count"] == 2

--- a/tests/test_grobid_dedup.py
+++ b/tests/test_grobid_dedup.py
@@ -1,0 +1,75 @@
+"""Tests for GROBID-aware spaCy NER deduplication."""
+
+from __future__ import annotations
+
+from biblicus.graph.grobid_dedup import (
+    grobid_blocked_surface_forms,
+    is_grobid_extraction_metadata,
+    should_suppress_ner_entity,
+)
+
+
+def test_is_grobid_extraction_metadata_method_flag():
+    assert is_grobid_extraction_metadata({"method": "grobid"}) is True
+    assert is_grobid_extraction_metadata({"method": "llm-html"}) is True
+    assert is_grobid_extraction_metadata({"method": "pypdf"}) is False
+    assert is_grobid_extraction_metadata({"method": "pypdf-fallback"}) is False
+
+
+def test_is_grobid_extraction_metadata_structured_authors():
+    assert is_grobid_extraction_metadata(
+        {"structured": {"authors": [{"name": "Jane Doe"}]}}
+    ) is True
+
+
+def test_grobid_blocked_surface_forms_includes_author_and_citation_tokens():
+    structured = {
+        "authors": [{"name": "Alice Wang", "normalized_name": "wang alice"}],
+        "citations": [
+            {
+                "title": "Deep Learning for NLP",
+                "raw": "Deep Learning for NLP (2020)",
+                "authors": ["Bob Smith"],
+            }
+        ],
+    }
+    blocked = grobid_blocked_surface_forms(structured)
+    assert "alice wang" in blocked
+    assert "wang" in blocked
+    assert "deep learning for nlp" in blocked
+    assert "bob smith" in blocked
+
+
+def test_should_suppress_ner_entity_exact_author_match():
+    blocked = grobid_blocked_surface_forms(
+        {"authors": [{"name": "Yann LeCun"}], "citations": []}
+    )
+    assert should_suppress_ner_entity(
+        label="Yann LeCun", entity_type="PER", blocked_forms=blocked
+    )
+    assert not should_suppress_ner_entity(
+        label="Geoffrey Hinton", entity_type="PER", blocked_forms=blocked
+    )
+
+
+def test_should_suppress_ner_entity_mislabeled_org_surname():
+    blocked = grobid_blocked_surface_forms(
+        {"authors": [{"name": "Zhang Wei"}], "citations": []}
+    )
+    assert should_suppress_ner_entity(
+        label="Zhang", entity_type="ORG", blocked_forms=blocked
+    )
+
+
+def test_should_suppress_ner_entity_citation_title():
+    blocked = grobid_blocked_surface_forms(
+        {
+            "authors": [],
+            "citations": [{"title": "Attention Is All You Need", "raw": "", "authors": []}],
+        }
+    )
+    assert should_suppress_ner_entity(
+        label="Attention Is All You Need",
+        entity_type="WORK_OF_ART",
+        blocked_forms=blocked,
+    )

--- a/tests/test_grobid_pdf_text.py
+++ b/tests/test_grobid_pdf_text.py
@@ -1,0 +1,71 @@
+"""Tests for GROBID PDF text extraction fallback metadata."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from biblicus.extractors.grobid_pdf_text import GrobidPortableDocumentFormatTextExtractor
+from biblicus.url_text import UrlTextExtractionError
+
+
+def test_grobid_pdf_text_records_fallback_metadata(monkeypatch, tmp_path):
+    extractor = GrobidPortableDocumentFormatTextExtractor()
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+    item = SimpleNamespace(
+        id="pdf-1",
+        relpath="paper.pdf",
+        media_type="application/pdf",
+    )
+    corpus = SimpleNamespace(root=tmp_path)
+
+    monkeypatch.setattr(
+        "biblicus.extractors.grobid_pdf_text._convert_pdf_with_grobid",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            UrlTextExtractionError(code="grobid_request_failed", message="down")
+        ),
+    )
+    monkeypatch.setattr(
+        "biblicus.extractors.grobid_pdf_text.PortableDocumentFormatTextExtractor.extract_text",
+        lambda self, **_kwargs: SimpleNamespace(text="pypdf body", producer_extractor_id="pdf-text"),
+    )
+
+    result = extractor.extract_text(
+        corpus=corpus,
+        item=item,
+        config={"fallback_to_pypdf": True, "record_fallback_metadata": True},
+        previous_extractions=[],
+    )
+    assert result is not None
+    assert result.producer_extractor_id == "grobid-pdf-text"
+    assert result.metadata["method"] == "pypdf-fallback"
+    assert result.metadata["grobid_fallback"]["code"] == "grobid_request_failed"
+
+
+def test_grobid_pdf_text_raises_without_fallback(monkeypatch, tmp_path):
+    extractor = GrobidPortableDocumentFormatTextExtractor()
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+    item = SimpleNamespace(
+        id="pdf-1",
+        relpath="paper.pdf",
+        media_type="application/pdf",
+    )
+    corpus = SimpleNamespace(root=tmp_path)
+
+    monkeypatch.setattr(
+        "biblicus.extractors.grobid_pdf_text._convert_pdf_with_grobid",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            UrlTextExtractionError(code="grobid_request_failed", message="down")
+        ),
+    )
+
+    with pytest.raises(UrlTextExtractionError):
+        extractor.extract_text(
+            corpus=corpus,
+            item=item,
+            config={"fallback_to_pypdf": False},
+            previous_extractions=[],
+        )

--- a/tests/test_grobid_runtime.py
+++ b/tests/test_grobid_runtime.py
@@ -1,0 +1,52 @@
+"""Tests for GROBID JIT runtime auto-start."""
+
+from __future__ import annotations
+
+import pytest
+
+from biblicus import grobid_runtime
+
+
+def test_resolve_grobid_base_url_defaults_to_localhost(monkeypatch):
+    monkeypatch.delenv("BIBLICUS_GROBID_URL", raising=False)
+    monkeypatch.delenv("PAPYRUS_GROBID_URL", raising=False)
+    assert grobid_runtime.resolve_grobid_base_url() == "http://127.0.0.1:8070"
+
+
+def test_ensure_grobid_running_skips_docker_when_already_alive(monkeypatch):
+    monkeypatch.setattr(grobid_runtime, "grobid_is_alive", lambda _url: True)
+    started = {"called": False}
+    monkeypatch.setattr(
+        grobid_runtime,
+        "_start_or_reuse_local_grobid_container",
+        lambda **_kwargs: started.__setitem__("called", True),
+    )
+    grobid_runtime._ENSURED_URL = None
+    url = grobid_runtime.ensure_grobid_running("http://127.0.0.1:8070")
+    assert url == "http://127.0.0.1:8070"
+    assert started["called"] is False
+
+
+def test_ensure_grobid_running_starts_local_container_when_down(monkeypatch):
+    alive = {"value": False}
+
+    def _alive(_url: str) -> bool:
+        return alive["value"]
+
+    def _start(**_kwargs):
+        alive["value"] = True
+
+    monkeypatch.setattr(grobid_runtime, "grobid_is_alive", _alive)
+    monkeypatch.setattr(grobid_runtime, "_start_or_reuse_local_grobid_container", _start)
+    monkeypatch.setattr(grobid_runtime, "_await_grobid_ready", lambda _url: None)
+    grobid_runtime._ENSURED_URL = None
+    url = grobid_runtime.ensure_grobid_running("http://127.0.0.1:8070")
+    assert url == "http://127.0.0.1:8070"
+    assert alive["value"] is True
+
+
+def test_ensure_grobid_running_rejects_remote_without_auto_start(monkeypatch):
+    monkeypatch.setattr(grobid_runtime, "grobid_is_alive", lambda _url: False)
+    grobid_runtime._ENSURED_URL = None
+    with pytest.raises(RuntimeError, match="Auto-start is only supported for localhost"):
+        grobid_runtime.ensure_grobid_running("http://grobid.internal:8070")

--- a/tests/test_html_extraction_pipeline_integration.py
+++ b/tests/test_html_extraction_pipeline_integration.py
@@ -1,0 +1,310 @@
+"""Integration tests for HTML metadata through pipeline, snapshots, and graph NER."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from biblicus import extraction
+from biblicus.corpus import Corpus
+from biblicus.extractors import get_extractor
+from biblicus.extractors.markitdown_text import MarkItDownExtractor
+from biblicus.extractors.select_override import SelectOverrideExtractor
+from biblicus.graph.extractors import ner_entities
+from biblicus.graph.grobid_dedup import grobid_blocked_surface_forms, is_grobid_extraction_metadata
+from biblicus.models import CatalogItem, ExtractedText, ExtractionStageOutput
+from biblicus.extractors.html_web_metadata import HtmlWebMetadataExtractor
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "html_heuristics"
+_RECIPE = Path(__file__).parent.parent / "configurations" / "extraction" / "ai-ml-research-topic-text.yml"
+
+
+def _read(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _run_pipeline_stages(
+    *,
+    corpus: Corpus,
+    item: CatalogItem,
+    markitdown_text: str,
+) -> tuple[ExtractedText | None, list[ExtractionStageOutput]]:
+    """Simulate pass-through → markitdown → html-web-metadata → select-override."""
+    stage_outputs: list[ExtractionStageOutput] = []
+
+    pass_result = get_extractor("pass-through-text").extract_text(
+        corpus=corpus,
+        item=item,
+        config={},
+        previous_extractions=stage_outputs,
+    )
+    if pass_result is not None:
+        stage_outputs.append(
+            ExtractionStageOutput(
+                stage_index=1,
+                extractor_id="pass-through-text",
+                status="extracted",
+                text=pass_result.text,
+                text_characters=len(pass_result.text or ""),
+                producer_extractor_id=pass_result.producer_extractor_id,
+                metadata=pass_result.metadata,
+            )
+        )
+
+    md_result = ExtractedText(text=markitdown_text, producer_extractor_id="markitdown")
+    stage_outputs.append(
+        ExtractionStageOutput(
+            stage_index=3,
+            extractor_id="markitdown",
+            status="extracted",
+            text=md_result.text,
+            text_characters=len(md_result.text),
+            producer_extractor_id="markitdown",
+        )
+    )
+
+    html_meta = HtmlWebMetadataExtractor().extract_text(
+        corpus=corpus,
+        item=item,
+        config={},
+        previous_extractions=stage_outputs,
+    )
+    assert html_meta is not None
+    stage_outputs.append(
+        ExtractionStageOutput(
+            stage_index=4,
+            extractor_id="html-web-metadata",
+            status="extracted",
+            text=html_meta.text,
+            text_characters=len(html_meta.text or ""),
+            producer_extractor_id=html_meta.producer_extractor_id,
+            metadata=html_meta.metadata,
+        )
+    )
+
+    final = SelectOverrideExtractor().extract_text(
+        corpus=corpus,
+        item=item,
+        config={
+            "media_type_patterns": ["text/html", "application/xhtml+xml"],
+            "fallback_to_first": True,
+        },
+        previous_extractions=stage_outputs,
+    )
+    return final, stage_outputs
+
+
+@pytest.fixture
+def html_corpus(tmp_path: Path) -> tuple[Corpus, CatalogItem]:
+    corpus = Corpus.init(tmp_path, force=True)
+    html_bytes = _read("synthetic_blog_json_ld.html").encode("utf-8")
+    ingest = corpus.ingest_item(
+        html_bytes,
+        filename="blog_post.html",
+        media_type="text/html",
+        tags=[],
+        metadata={"sourceUri": "https://fixture.test/blog/post"},
+        source_uri="https://fixture.test/blog/post",
+    )
+    catalog = corpus.load_catalog()
+    item = catalog.items[ingest.item_id]
+    return corpus, item
+
+
+def test_recipe_includes_html_web_metadata_stage():
+    recipe = yaml.safe_load(_RECIPE.read_text(encoding="utf-8"))
+    stage_ids = [stage["extractor_id"] for stage in recipe["configuration"]["stages"]]
+    assert "html-web-metadata" in stage_ids
+    assert stage_ids.index("html-web-metadata") < stage_ids.index("select-override")
+    assert stage_ids.index("markitdown") < stage_ids.index("html-web-metadata")
+
+
+@pytest.mark.parametrize(
+    "fixture_name,min_authors,min_citations",
+    [
+        ("synthetic_blog_json_ld.html", 2, 1),
+        ("synthetic_news_open_graph.html", 1, 0),
+        ("synthetic_references_only.html", 0, 1),
+    ],
+)
+def test_html_web_metadata_fixtures(tmp_path: Path, fixture_name: str, min_authors: int, min_citations: int):
+    corpus = Corpus.init(tmp_path, force=True)
+    corpus.ingest_item(
+        _read(fixture_name).encode("utf-8"),
+        filename=fixture_name,
+        media_type="text/html",
+        tags=[],
+        metadata=None,
+        source_uri=f"https://fixture.test/{fixture_name}",
+    )
+    item = corpus.load_catalog().items[corpus.load_catalog().order[0]]
+    final, _ = _run_pipeline_stages(
+        corpus=corpus,
+        item=item,
+        markitdown_text="# Body\n\nConverted content for NER.",
+    )
+    assert final is not None
+    assert is_grobid_extraction_metadata(final.metadata)
+    structured = final.metadata["structured"]
+    assert len(structured.get("authors") or []) >= min_authors
+    assert len(structured.get("citations") or []) >= min_citations
+
+
+def test_pipeline_select_override_carries_html_metadata(html_corpus: tuple[Corpus, CatalogItem]):
+    corpus, item = html_corpus
+    final, stages = _run_pipeline_stages(
+        corpus=corpus,
+        item=item,
+        markitdown_text="# Sequence models\n\nArticle body mentioning Alex Example.",
+    )
+    assert final is not None
+    assert final.metadata.get("method") == "html-heuristics"
+    assert final.text != stages[0].text or "Sequence" in final.text
+    html_stage = next(s for s in stages if s.extractor_id == "html-web-metadata")
+    assert final.metadata == html_stage.metadata
+
+
+def test_write_snapshot_metadata_roundtrip(html_corpus: tuple[Corpus, CatalogItem], tmp_path: Path):
+    corpus, item = html_corpus
+    final, _ = _run_pipeline_stages(
+        corpus=corpus,
+        item=item,
+        markitdown_text="# Title\n\nContent.",
+    )
+    assert final is not None
+    snap_dir = corpus.extraction_snapshot_dir(extractor_id="pipeline", snapshot_id="snap-html-test")
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    relpath = extraction.write_extracted_metadata_artifact(
+        snapshot_dir=snap_dir,
+        item=item,
+        metadata=final.metadata,
+    )
+    assert relpath is not None
+    written = json.loads((snap_dir / relpath).read_text(encoding="utf-8"))
+    assert written["method"] == "html-heuristics"
+    assert is_grobid_extraction_metadata(written)
+
+
+def test_graph_ner_suppresses_heuristic_authors_from_snapshot_metadata(
+    html_corpus: tuple[Corpus, CatalogItem],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    corpus, item = html_corpus
+    final, _ = _run_pipeline_stages(
+        corpus=corpus,
+        item=item,
+        markitdown_text="Alex Example and Blair Sample discuss sequence models in this article.",
+    )
+    assert final is not None
+    snap_dir = corpus.extraction_snapshot_dir(extractor_id="pipeline", snapshot_id="snap-ner")
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    relpath = extraction.write_extracted_metadata_artifact(
+        snapshot_dir=snap_dir,
+        item=item,
+        metadata=final.metadata,
+    )
+    extraction.write_extracted_text_artifact(
+        snapshot_dir=snap_dir,
+        item=item,
+        text=final.text or "",
+    )
+
+    class _FakeEnt:
+        def __init__(self, text: str, label: str) -> None:
+            self.text = text
+            self.label_ = label
+            self.sent = type("S", (), {"start": 0})()
+
+    class _FakeDoc:
+        def __init__(self, ents) -> None:
+            self.ents = ents
+
+    def fake_nlp(_text: str):
+        return _FakeDoc(
+            [
+                _FakeEnt("Alex Example", "PER"),
+                _FakeEnt("Stanford University", "ORG"),
+            ]
+        )
+
+    monkeypatch.setattr(ner_entities, "_load_spacy_pipeline", lambda _name: fake_nlp)
+
+    loaded = json.loads((snap_dir / relpath).read_text(encoding="utf-8"))
+    assert is_grobid_extraction_metadata(loaded)
+    blocked = grobid_blocked_surface_forms(loaded["structured"])
+    assert "alex example" in blocked
+
+    entities = ner_entities._extract_entities(
+        extracted_text=final.text or "",
+        model_name="en",
+        min_length=2,
+        max_length=120,
+        entity_labels=["PER", "ORG"],
+        grobid_blocked_forms=blocked,
+    )
+    labels = {text for text, _label, _idx in entities}
+    assert "Alex Example" not in labels
+    assert "Stanford University" in labels
+
+
+def test_build_extraction_snapshot_html_pipeline(
+    html_corpus: tuple[Corpus, CatalogItem],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    corpus, item = html_corpus
+
+    def fake_markitdown_extract(self, *, corpus, item, config, previous_extractions):
+        return ExtractedText(
+            text="# Understanding Sequence Models\n\nMarkdown body.",
+            producer_extractor_id="markitdown",
+        )
+
+    monkeypatch.setattr(MarkItDownExtractor, "extract_text", fake_markitdown_extract)
+    monkeypatch.delenv("AMPLIFY_AUTO_SYNC_CATALOG", raising=False)
+
+    recipe = yaml.safe_load(_RECIPE.read_text(encoding="utf-8"))
+    manifest = extraction.build_extraction_snapshot(
+        corpus=corpus,
+        extractor_id="pipeline",
+        configuration_name="ai-ml-research-topic-text-test",
+        configuration=recipe["configuration"],
+        force=True,
+        max_workers=1,
+    )
+    assert manifest.stats.get("extracted_items", 0) >= 1
+    item_summary = next(row for row in manifest.items if row.item_id == item.id)
+    assert item_summary.status == "extracted"
+    assert item_summary.final_metadata_relpath
+
+    snap_dir = corpus.extraction_snapshot_dir(
+        extractor_id="pipeline",
+        snapshot_id=manifest.snapshot_id,
+    )
+    meta_path = snap_dir / item_summary.final_metadata_relpath
+    payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert payload.get("method") == "html-heuristics"
+    assert is_grobid_extraction_metadata(payload)
+    assert len(payload.get("structured", {}).get("authors") or []) >= 2
+
+
+def test_html_web_metadata_returns_none_without_prior_text(tmp_path: Path):
+    corpus = Corpus.init(tmp_path, force=True)
+    corpus.ingest_item(
+        b"<html><body>Hi</body></html>",
+        filename="orphan.html",
+        media_type="text/html",
+        tags=[],
+        metadata=None,
+        source_uri="https://fixture.test/orphan",
+    )
+    item = corpus.load_catalog().items[corpus.load_catalog().order[0]]
+    result = HtmlWebMetadataExtractor().extract_text(
+        corpus=corpus,
+        item=item,
+        config={},
+        previous_extractions=[],
+    )
+    assert result is None

--- a/tests/test_html_heuristics.py
+++ b/tests/test_html_heuristics.py
@@ -1,0 +1,79 @@
+"""Unit tests for HTML heuristic extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from biblicus.html_heuristics import (
+    extract_html_heuristics,
+    heuristic_document_to_structured,
+    structured_metadata_is_sufficient,
+)
+from biblicus.html_structured_pipeline import enrich_web_extraction_structured
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "html_heuristics"
+
+
+def _read(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_json_ld_blog_fixture_authors_and_references():
+    doc = extract_html_heuristics(_read("synthetic_blog_json_ld.html"))
+    structured = heuristic_document_to_structured(doc)
+    assert doc.title == "Understanding Sequence Models"
+    assert len(doc.authors) >= 2
+    assert doc.publication_date == "2021-03-15"
+    assert len(structured["citations"]) >= 2
+    assert structured_metadata_is_sufficient(structured)
+
+
+def test_open_graph_news_fixture():
+    doc = extract_html_heuristics(_read("synthetic_news_open_graph.html"))
+    assert doc.title == "Corpus Audit Checklist"
+    assert doc.publication_date == "2024-11-02"
+    assert any(author["name"] == "Casey Reviewer" for author in doc.authors)
+
+
+def test_footer_links_require_external_hosts():
+    doc = extract_html_heuristics(
+        _read("synthetic_footer_links.html"),
+        source_uri="https://fixture.test/articles/footer",
+    )
+    urls = {row.get("url") for row in doc.citations}
+    assert "https://example.test/external/paper-a" in urls
+    assert all("/internal/" not in (url or "") for url in urls)
+
+
+def test_pipeline_skips_llm_when_heuristics_sufficient(monkeypatch):
+    monkeypatch.setenv("BIBLICUS_HTML_LLM_STRUCTURED", "0")
+    enriched = enrich_web_extraction_structured(
+        {"text": "body", "markdown": "body"},
+        source_uri="https://fixture.test/blog",
+        html_content=_read("synthetic_blog_json_ld.html"),
+    )
+    assert enriched["method"] == "html-heuristics"
+    assert len(enriched["structured"]["authors"]) >= 2
+
+
+def test_pipeline_llm_fallback_when_sparse(monkeypatch):
+    monkeypatch.setenv("BIBLICUS_HTML_LLM_STRUCTURED", "1")
+
+    def resolver(*, model: str, messages: list[dict[str, str]]) -> dict:
+        turn = sum(1 for row in messages if row.get("role") == "assistant")
+        if turn == 0:
+            return {"authors": [{"name": "Fallback Author", "normalized_name": "author fallback"}]}
+        if turn == 1:
+            return {"publication_date": None, "raw": None}
+        return {"citations": [{"title": "Fallback Citation", "authors": ["A. Reader"], "year": 2021}]}
+
+    enriched = enrich_web_extraction_structured(
+        {"text": "body"},
+        source_uri="https://fixture.test/sparse",
+        html_content=_read("synthetic_sparse.html"),
+        completion_resolver=resolver,
+    )
+    assert enriched["method"] == "llm-html"
+    assert enriched["structured"]["authors"][0]["name"] == "Fallback Author"

--- a/tests/test_html_structured.py
+++ b/tests/test_html_structured.py
@@ -1,0 +1,123 @@
+"""Tests for LLM HTML structured metadata extraction."""
+
+from __future__ import annotations
+
+from biblicus.graph.grobid_dedup import (
+    grobid_blocked_surface_forms,
+    is_grobid_extraction_metadata,
+    should_suppress_ner_entity,
+)
+from biblicus.html_structured import (
+    HTML_STRUCTURED_DEFAULT_MODEL,
+    enrich_web_extraction_with_llm_structured,
+    extract_html_structured_metadata,
+    html_llm_structured_enabled,
+)
+from biblicus import html_structured as html_structured_module
+from biblicus import html_structured_pipeline as pipeline_module
+from biblicus import url_text as url_text_module
+
+
+def test_html_llm_structured_three_turn_conversation_order():
+    calls: list[list[dict[str, str]]] = []
+
+    def fake_resolver(*, model: str, messages: list[dict[str, str]]) -> dict:
+        calls.append(list(messages))
+        turn = len(calls)
+        if turn == 1:
+            return {"authors": [{"name": "Jane Doe", "normalized_name": "doe jane"}]}
+        if turn == 2:
+            return {"publication_date": "2024-06-15", "raw": "June 15, 2024"}
+        return {
+            "citations": [
+                {
+                    "title": "Prior Work on Transformers",
+                    "authors": ["Alan Turing"],
+                    "year": 2017,
+                    "doi": "10.1000/xyz",
+                    "citing_context": "They introduced the core attention mechanism we build on.",
+                }
+            ]
+        }
+
+    structured, meta = extract_html_structured_metadata(
+        article_content="<html><body><p>Article</p></body></html>",
+        content_kind="html",
+        source_uri="https://example.test/paper",
+        completion_resolver=fake_resolver,
+    )
+    assert meta["model"] == HTML_STRUCTURED_DEFAULT_MODEL
+    assert len(calls) == 3
+    assert len(calls[1]) > len(calls[0])
+    assert len(calls[2]) > len(calls[1])
+    assert structured["authors"][0]["name"] == "Jane Doe"
+    assert structured["publication_date"] == "2024-06-15"
+    assert structured["citations"][0]["citing_context"].startswith("They introduced")
+    assert meta["turns"] == 3
+
+
+def test_enrich_web_extraction_attaches_llm_html_method(monkeypatch):
+    monkeypatch.setattr(html_structured_module, "html_llm_structured_enabled", lambda: True)
+
+    def fake_enrich(converted, **kwargs):
+        return {
+            **converted,
+            "method": "llm-html",
+            "structured": {
+                "authors": [{"name": "Ada Lovelace", "normalized_name": "lovelace ada"}],
+                "citations": [],
+                "publication_date": "1843-01-01",
+                "summary": {"authors_count": 1, "citations_count": 0, "citations_with_identifiers": 0},
+                "warnings": [],
+            },
+        }
+
+    monkeypatch.setattr(url_text_module, "enrich_web_extraction_structured", fake_enrich)
+    monkeypatch.setattr(
+        url_text_module,
+        "_fetch_url_bytes",
+        lambda **kwargs: {
+            "ok": True,
+            "body": b"# Title\n\nBody",
+            "content_type": "text/markdown",
+            "final_url": kwargs["uri"],
+            "attempts": [],
+            "error": None,
+        },
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_bytes_with_markitdown",
+        lambda **kwargs: {"text": "Body", "markdown": "# Title\n\nBody", "title": "Title"},
+    )
+    monkeypatch.setattr(
+        url_text_module,
+        "_convert_direct_with_markitdown",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("direct should not run")),
+    )
+
+    result = url_text_module.extract_url_text(source_uri="https://example.test/article")
+    assert result["status"] == "ok"
+    assert result["method"] == "llm-html"
+    assert result["structured"]["authors"][0]["name"] == "Ada Lovelace"
+
+
+def test_is_grobid_extraction_metadata_llm_html():
+    assert is_grobid_extraction_metadata({"method": "llm-html"}) is True
+
+
+def test_blocked_surface_forms_include_publication_date():
+    blocked = grobid_blocked_surface_forms(
+        {
+            "authors": [{"name": "Jane Doe"}],
+            "citations": [],
+            "publication_date": "2024-06-15",
+            "publication_date_raw": "June 15, 2024",
+        }
+    )
+    assert "2024 06 15" in blocked
+    assert should_suppress_ner_entity(
+        label="June 15, 2024",
+        entity_type="DATE",
+        blocked_forms=blocked,
+    )

--- a/tests/test_html_web_metadata.py
+++ b/tests/test_html_web_metadata.py
@@ -1,0 +1,96 @@
+"""Tests for HTML web metadata pipeline extractor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from biblicus.extractors.html_web_metadata import HtmlWebMetadataExtractor
+from biblicus.graph.grobid_dedup import is_grobid_extraction_metadata
+from biblicus.models import ExtractionStageOutput
+from biblicus.web_reference_metadata import extraction_metadata_from_web_payload
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "html_heuristics"
+
+
+def _read(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_extraction_metadata_from_web_payload_shapes_graph_fields():
+    metadata = extraction_metadata_from_web_payload(
+        {
+            "method": "html-heuristics",
+            "title": "Example",
+            "authors": ["Alex Example"],
+            "structured": {"authors": [{"name": "Alex Example"}], "citations": [{"title": "Paper"}]},
+            "layers": ["json_ld"],
+        }
+    )
+    assert metadata["method"] == "html-heuristics"
+    assert is_grobid_extraction_metadata(metadata)
+    assert metadata["structured"]["authors"][0]["name"] == "Alex Example"
+
+
+def test_html_web_metadata_skips_non_html(tmp_path):
+    extractor = HtmlWebMetadataExtractor()
+    item = SimpleNamespace(
+        id="pdf-1",
+        relpath="paper.pdf",
+        media_type="application/pdf",
+        title="",
+        source_uri=None,
+        metadata={},
+    )
+    corpus = SimpleNamespace(root=tmp_path)
+    prior = ExtractionStageOutput(
+        stage_index=2,
+        extractor_id="markitdown",
+        status="extracted",
+        text="pdf body",
+        text_characters=8,
+        producer_extractor_id="markitdown",
+    )
+    result = extractor.extract_text(
+        corpus=corpus,
+        item=item,
+        config={},
+        previous_extractions=[prior],
+    )
+    assert result is None
+
+
+def test_html_web_metadata_attaches_structured_metadata(tmp_path):
+    html_path = tmp_path / "article.html"
+    html_path.write_text(_read("synthetic_blog_json_ld.html"), encoding="utf-8")
+    extractor = HtmlWebMetadataExtractor()
+    item = SimpleNamespace(
+        id="html-1",
+        relpath="article.html",
+        media_type="text/html",
+        title="",
+        source_uri="https://fixture.test/blog/post",
+        metadata={},
+    )
+    corpus = SimpleNamespace(root=tmp_path)
+    prior = ExtractionStageOutput(
+        stage_index=3,
+        extractor_id="markitdown",
+        status="extracted",
+        text="# Markdown body from markitdown",
+        text_characters=28,
+        producer_extractor_id="markitdown",
+    )
+    result = extractor.extract_text(
+        corpus=corpus,
+        item=item,
+        config={},
+        previous_extractions=[prior],
+    )
+    assert result is not None
+    assert result.text == prior.text
+    assert result.metadata["method"] == "html-heuristics"
+    assert is_grobid_extraction_metadata(result.metadata)
+    structured = result.metadata["structured"]
+    assert len(structured.get("authors") or []) >= 2
+    assert len(structured.get("citations") or []) >= 1

--- a/tests/test_markitdown_html.py
+++ b/tests/test_markitdown_html.py
@@ -1,0 +1,59 @@
+"""Tests that MarkItDown runs on HTML corpus items (not skipped as generic text/*)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from biblicus.extractors import markitdown_text as md_mod
+from biblicus.extractors.markitdown_text import MarkItDownExtractor
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "html_heuristics" / "synthetic_blog_json_ld.html"
+
+
+def test_text_html_is_not_in_markitdown_skip_list():
+    assert "text/html" not in md_mod._MARKITDOWN_SKIP_MEDIA_TYPES
+    media_type = "text/html"
+    assert not (
+        media_type.startswith("text/")
+        and media_type not in {"text/html", "application/xhtml+xml"}
+    )
+
+
+def test_text_plain_is_skipped_by_markitdown(tmp_path):
+    plain_path = tmp_path / "note.txt"
+    plain_path.write_text("hello", encoding="utf-8")
+    extractor = MarkItDownExtractor()
+    result = extractor.extract_text(
+        corpus=SimpleNamespace(root=tmp_path),
+        item=SimpleNamespace(relpath="note.txt", media_type="text/plain"),
+        config={},
+        previous_extractions=[],
+    )
+    assert result is None
+
+
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("markitdown"),
+    reason="markitdown optional dependency not installed",
+)
+def test_markitdown_converts_text_html_file(tmp_path, monkeypatch):
+    html_path = tmp_path / "page.html"
+    html_path.write_text(_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    mock_converter = MagicMock()
+    mock_converter.convert.return_value = SimpleNamespace(text_content="# Converted markdown")
+    monkeypatch.setattr("markitdown.MarkItDown", lambda **kwargs: mock_converter)
+
+    extractor = MarkItDownExtractor()
+    result = extractor.extract_text(
+        corpus=SimpleNamespace(root=tmp_path),
+        item=SimpleNamespace(relpath="page.html", media_type="text/html"),
+        config={},
+        previous_extractions=[],
+    )
+    assert result is not None
+    assert "Converted" in result.text
+    mock_converter.convert.assert_called_once()

--- a/tests/test_ner_entities_grobid.py
+++ b/tests/test_ner_entities_grobid.py
@@ -1,0 +1,103 @@
+"""Tests for NER graph extraction with GROBID deduplication."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from biblicus.graph.extractors import ner_entities
+
+
+class _FakeEnt:
+    def __init__(self, text: str, label: str) -> None:
+        self.text = text
+        self.label_ = label
+        self.sent = SimpleNamespace(start=0)
+
+
+class _FakeDoc:
+    def __init__(self, ents) -> None:
+        self.ents = ents
+
+
+def test_extract_entities_suppresses_grobid_authors(monkeypatch):
+    def fake_nlp(_text):
+        return _FakeDoc(
+            [
+                _FakeEnt("Alice Wang", "PER"),
+                _FakeEnt("Stanford University", "ORG"),
+                _FakeEnt("Wang", "ORG"),
+            ]
+        )
+
+    monkeypatch.setattr(
+        "biblicus.graph.extractors.ner_entities._load_spacy_pipeline",
+        lambda _name: fake_nlp,
+    )
+
+    blocked = {"alice wang", "wang"}
+    entities = ner_entities._extract_entities(
+        extracted_text="ignored",
+        model_name="fake",
+        min_length=2,
+        max_length=120,
+        entity_labels=["PER", "ORG"],
+        grobid_blocked_forms=blocked,
+    )
+    labels = {text for text, _label, _idx in entities}
+    assert "Alice Wang" not in labels
+    assert "Wang" not in labels
+    assert "Stanford University" in labels
+
+
+def test_extract_graph_passes_grobid_blocked_forms_when_metadata_present(monkeypatch):
+    captured: dict = {}
+
+    def fake_extract(**kwargs):
+        captured.update(kwargs)
+        return [("Stanford University", "ORG", 0)]
+
+    monkeypatch.setattr(ner_entities, "_extract_entities", fake_extract)
+    extractor = ner_entities.NerEntitiesGraphExtractor()
+    extractor.extract_graph(
+        corpus=SimpleNamespace(),
+        item=SimpleNamespace(id="i1", title="t", relpath="r"),
+        extracted_text="Alice Wang works at Stanford University.",
+        config={
+            "model": "en",
+            "min_entity_length": 2,
+            "include_item_node": False,
+            "include_relation_edges": False,
+        },
+        extraction_metadata={
+            "method": "grobid",
+            "structured": {"authors": [{"name": "Alice Wang"}], "citations": []},
+        },
+    )
+    blocked = captured.get("grobid_blocked_forms")
+    assert blocked is not None
+    assert "alice wang" in blocked
+    assert "wang" in blocked
+
+
+def test_extract_graph_omits_grobid_blocked_forms_without_grobid_metadata(monkeypatch):
+    captured: dict = {}
+
+    def fake_extract(**kwargs):
+        captured.update(kwargs)
+        return [("OpenAI", "ORG", 0)]
+
+    monkeypatch.setattr(ner_entities, "_extract_entities", fake_extract)
+    extractor = ner_entities.NerEntitiesGraphExtractor()
+    extractor.extract_graph(
+        corpus=SimpleNamespace(),
+        item=SimpleNamespace(id="i1", title="t", relpath="r"),
+        extracted_text="OpenAI builds models.",
+        config={
+            "model": "en",
+            "min_entity_length": 2,
+            "include_item_node": False,
+            "include_relation_edges": False,
+        },
+        extraction_metadata=None,
+    )
+    assert captured.get("grobid_blocked_forms") is None

--- a/tests/test_web_reference_metadata.py
+++ b/tests/test_web_reference_metadata.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from biblicus.web_reference_metadata import (
     extract_web_reference_metadata_from_html,
+    extraction_metadata_from_web_payload,
     title_subtitle_resolution_from_web_metadata,
 )
 
@@ -14,6 +15,16 @@ _FIXTURES = Path(__file__).parent / "fixtures" / "html_heuristics"
 
 def _read(name: str) -> str:
     return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_extraction_metadata_from_web_payload_fixture():
+    payload = extract_web_reference_metadata_from_html(
+        _read("synthetic_blog_json_ld.html"),
+        source_uri="https://fixture.test/blog/post",
+    )
+    metadata = extraction_metadata_from_web_payload(payload)
+    assert metadata["method"] == "html-heuristics"
+    assert metadata["structured"].get("authors")
 
 
 def test_web_metadata_from_json_ld_fixture():

--- a/tests/test_web_reference_metadata.py
+++ b/tests/test_web_reference_metadata.py
@@ -1,0 +1,40 @@
+"""Tests for shared web reference metadata extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from biblicus.web_reference_metadata import (
+    extract_web_reference_metadata_from_html,
+    title_subtitle_resolution_from_web_metadata,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "html_heuristics"
+
+
+def _read(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_web_metadata_from_json_ld_fixture():
+    payload = extract_web_reference_metadata_from_html(
+        _read("synthetic_blog_json_ld.html"),
+        source_uri="https://fixture.test/blog/post",
+    )
+    assert payload["title"] == "Understanding Sequence Models"
+    assert "json_ld" in payload["layers"]
+    assert len(payload["authors"]) >= 2
+    assert payload["citationCount"] >= 2
+    resolution = title_subtitle_resolution_from_web_metadata(payload)
+    assert resolution["title"] == payload["title"]
+    assert resolution["titleMode"] == "original_web_metadata"
+
+
+def test_web_metadata_from_open_graph_fixture():
+    payload = extract_web_reference_metadata_from_html(
+        _read("synthetic_news_open_graph.html"),
+        source_uri="https://fixture.test/news/story",
+    )
+    assert payload["title"] == "Corpus Audit Checklist"
+    assert payload["publicationDate"] == "2024-11-02"
+    assert any(name == "Casey Reviewer" for name in payload["authors"])


### PR DESCRIPTION
## Summary

Pushes five commits from local main that could not land on protected main directly:

1. **HTML heuristics metadata** — html_heuristics / web_reference_metadata extraction for corpus HTML items.
2. **Structured NER deduplication** — grobid_dedup wiring for graph NER (ner-entities).
3. **GROBID PDF pipeline** — pipeline config, hardened pypdf fallback, pilot scripts.
4. **HTML extraction fixes** — persist heuristic metadata in snapshots; markitdown text/html fix; integration tests.
5. **Graph extraction plumbing** — GraphExport models, Neo4j helpers, execution override handling (graph.max_items), HTML metadata backfill when text exists but metadata JSON is missing.

## Testing

- HTML metadata backfill verified on AI-ML-research corpus (66/67 HTML items with metadata in snapshot pipeline:d746ca5b...).
- Graph NER pilot (3 items) succeeded after graph model/Neo4j fixes.